### PR TITLE
Adds target support for linux over SSH in ec2

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -61,6 +61,14 @@ class Ohai::Application
     long: "--target TARGET",
     description: "Target a remote location to invoke Ohai",
     on: :on
+  
+  # NOTE: This cli library does not support multiple parameters making
+  #   this not paralleled by what is offered by inspec.
+  option :keyfiles,
+    short: "-i TARGET",
+    long: "--key-file=KEYFILE",
+    description: "Login key or certificate file for a remote scan.",
+    on: :on
 
   option :help,
     short: "-h",

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -56,6 +56,12 @@ class Ohai::Application
     description: "Set the log file location, defaults to STDOUT - recommended for daemonizing",
     proc: nil
 
+  option :target,
+    short: "-t TARGET",
+    long: "--target TARGET",
+    description: "Target a remote location to invoke Ohai",
+    on: :on
+
   option :help,
     short: "-h",
     long: "--help",
@@ -90,7 +96,6 @@ class Ohai::Application
   def configure_ohai
     @attributes = parse_options
     @attributes = nil if @attributes.empty?
-
     load_workstation_config
 
     Ohai::Log.init(Ohai.config[:log_location])

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -133,6 +133,23 @@ module Ohai
         data[:backend].file(filename).exist?
       end
 
+      # This is to provide a replacement for `File.open`
+      # returning a stringio gets you support for `gets` `lines`
+      # taking the block brings it on par with `File.open` use of block
+      def file_open(filename)
+        file_object = StringIO.new data[:backend].file(filename)
+        yield file_object if block_given?
+        file_object
+      end
+
+      # This is to provide a replacement for `File.executable?`
+      def file_executable?(filename)
+        binding.require 'pry' ; binding.pry
+        data[:backend].file(filename)
+        puts "Currently this may work"
+        true
+      end
+
       # This is to provide a replacement for `File.read`
       def file_read(filename)
         data[:backend].file(filename).content

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -128,6 +128,7 @@ module Ohai
 
       # This is to provide a replacement for `File.exist?`
       def file_exist?(filename)
+        # require 'pry' ; binding.pry
         data[:backend].file(filename).exist?
       end
 
@@ -142,7 +143,7 @@ module Ohai
 
       # This is to provide a replacement for `File.executable?`
       def file_executable?(filename)
-        binding.require 'pry' ; binding.pry
+        # require 'pry' ; binding.pry
         data[:backend].file(filename)
         puts "Currently this may work"
         true
@@ -150,6 +151,7 @@ module Ohai
 
       # This is to provide a replacement for `File.read`
       def file_read(filename)
+        # require 'pry' ; binding.pry
         data[:backend].file(filename).content
       end
 

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -106,9 +106,8 @@ module Ohai
       # include Ohai::Util::FileHelper
       # This mixin is replaced currently with this method.
       def which(cmd)
-        # require 'pry' ; binding.pry
         # paths = ENV["PATH"].split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
-        paths = data[:backend].run_command("echo $PATH").split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
+        paths = data[:backend].run_command("echo $PATH").stdout.split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
         paths.each do |path|
           filename = File.join(path, cmd)
           
@@ -116,10 +115,9 @@ module Ohai
           #   At the moment I don't know how to get the current user (local and remote)
 
           # find the file stats => mode => convert to octal
-          backend_file_mode = data[:backend].file(filename).stat.mode
-
+          backend_file_mode = data[:backend].file(filename).stat[:mode]
           # if File.executable?(filename)
-          if backend_file_mode.to_s(8) == "755"
+          if backend_file_mode.to_i.to_s(8) == "755"
             logger.trace("Plugin #{name}: found #{cmd} at #{filename}")
             return filename
           end

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -137,6 +137,11 @@ module Ohai
         result
       end
 
+      def can_connect?(address, port = 80, timeout = 2)
+        # require 'pry' ; binding.pry
+        shell_out("curl -Is #{address}:#{port} --connect-timeout #{timeout}").exit_status == 0
+      end
+
       include Ohai::Mixin::SecondsToHuman
       
       # include Ohai::Util::FileHelper

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -137,7 +137,7 @@ module Ohai
       # returning a stringio gets you support for `gets` `lines`
       # taking the block brings it on par with `File.open` use of block
       def file_open(filename)
-        file_object = StringIO.new data[:backend].file(filename)
+        file_object = StringIO.new data[:backend].file(filename).content
         yield file_object if block_given?
         file_object
       end

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -136,9 +136,13 @@ module Ohai
       # returning a stringio gets you support for `gets` `lines`
       # taking the block brings it on par with `File.open` use of block
       def file_open(filename)
-        file_object = StringIO.new data[:backend].file(filename).content
-        yield file_object if block_given?
-        file_object
+        # require 'pry' ; binding.pry
+        content = data[:backend].file(filename).content
+        # NOTE: I need to look at the interface for File.open better.
+        #   it seems with a block passed you use the content in the block
+        #   but you return an IO object.
+        yield content if block_given?
+        StringIO.new content
       end
 
       # This is to provide a replacement for `File.executable?`

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -213,6 +213,17 @@ module Ohai
         response.code == "200" ? response.body : nil
       end
 
+      def json?(data)
+        data = StringIO.new(data)
+        parser = FFI_Yajl::Parser.new
+        begin
+          parser.parse(data)
+          true
+        rescue FFI_Yajl::ParseError
+          false
+        end
+      end
+
       def fetch_dynamic_data
         @fetch_dynamic_data ||= begin
           response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/")

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -47,7 +47,7 @@ Ohai.plugin(:Azure) do
   # check for either the waagent or the unknown-245 DHCP option that Azure uses
   # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
   def has_waagent?
-    if File.exist?("/usr/sbin/waagent") || Dir.exist?('C:\WindowsAzure')
+    if file_exist?("/usr/sbin/waagent") || file_exist?('C:\WindowsAzure')
       logger.trace("Plugin Azure: Found waagent used by Azure.")
       true
     end
@@ -55,7 +55,7 @@ Ohai.plugin(:Azure) do
 
   def has_dhcp_option_245?
     has_245 = false
-    if File.exist?("/var/lib/dhcp/dhclient.eth0.leases")
+    if file_exist?("/var/lib/dhcp/dhclient.eth0.leases")
       File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -56,7 +56,7 @@ Ohai.plugin(:Azure) do
   def has_dhcp_option_245?
     has_245 = false
     if file_exist?("/var/lib/dhcp/dhclient.eth0.leases")
-      File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
+      file_open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
           has_245 = true

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -66,7 +66,7 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect bhyve by presence of /dev/vmm
-    if File.exist?("/dev/vmm")
+    if file_exist?("/dev/vmm")
       virtualization[:system] = "bhyve"
       virtualization[:role] = "host"
       virtualization[:systems][:bhyve] = "host"

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:C) do
 
   def collect(cmd, &block)
     so = shell_out(cmd)
-    if so.exitstatus == 0
+    if so.exit_status == 0
       yield(so)
     else
       logger.trace("Plugin C: '#{cmd}' failed. Skipping data.")
@@ -34,7 +34,7 @@ Ohai.plugin(:C) do
   def xcode_installed?
     logger.trace("Plugin C: Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       logger.trace("Plugin C: Xcode Command Line Tools found.")
       return true
     else
@@ -125,7 +125,7 @@ Ohai.plugin(:C) do
     # ibm xlc
 
     so = shell_out("xlc -qversion")
-    if so.exitstatus == 0 || (so.exitstatus >> 8) == 249
+    if so.exit_status == 0 || (so.exit_status >> 8) == 249
       description = so.stdout.split($/).first
       if description =~ /V(\d+\.\d+)/
         @c[:xlc] = Mash.new

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -21,6 +21,7 @@ Ohai.plugin(:Chef) do
 
   collect_data do
     begin
+      # TODO: This approach to finding the chef version will not work remotely
       require "chef/version"
     rescue Gem::LoadError
       logger.trace("Plugin Chef: Unable to load the chef gem to determine the version")

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -122,7 +122,7 @@ Ohai.plugin(:CPU) do
       begin
         logger.trace("Plugin CPU: Falling back to aggregate data from lscpu as real cpu & core data is missing in /proc/cpuinfo")
         so = shell_out("lscpu")
-        if so.exitstatus == 0
+        if so.exit_status == 0
           lscpu_data = Mash.new
           so.stdout.each_line do |line|
             case line

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:CPU) do
   def parse_bsd_dmesg(&block)
     cpuinfo = Mash.new
     cpuinfo["flags"] = []
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
@@ -53,7 +53,7 @@ Ohai.plugin(:CPU) do
     cpu_number = 0
     current_cpu = nil
 
-    File.open("/proc/cpuinfo").each do |line|
+    file_open("/proc/cpuinfo").each do |line|
       case line
       when /processor\s+:\s(.+)/
         cpuinfo[$1] = Mash.new
@@ -212,7 +212,7 @@ Ohai.plugin(:CPU) do
     # to scrape from dmesg.boot is the cpu feature list.
     # cpu0: FPU,V86,DE,PSE,TSC,MSR,MCE,CX8,SEP,MTRR,PGE,MCA,CMOV,PAT,CFLUSH,DS,ACPI,MMX,FXSR,SSE,SSE2,SS,TM,SBF,EST,TM2
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu\d+:\s+([A-Z]+$|[A-Z]+,.*$)/
         cpuinfo["flags"] = $1.downcase.split(",")
@@ -235,7 +235,7 @@ Ohai.plugin(:CPU) do
     # available instruction set
     # cpu0 at mainbus0 apid 0: Intel 686-class, 2134MHz, id 0x6f6
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu[\d\w\s]+:\s([\w\s\-]+),\s+(\w+),/
         cpuinfo[:model_name] = $1

--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -91,7 +91,7 @@ Ohai.plugin(:Network) do
     counters Mash.new unless counters
     counters[:network] = Mash.new unless counters[:network]
 
-    so = shell_out("route -n get default")
+    so = shell_out("#{which("route")} -n get default")
     so.stdout.lines do |line|
       if line =~ /(\w+): ([\w\.]+)/
         case $1
@@ -104,7 +104,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("ifconfig -a")
+    so = shell_out("#{which("ifconfig")} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)$/
@@ -159,7 +159,7 @@ Ohai.plugin(:Network) do
       end
     end
 
-    so = shell_out("arp -an")
+    so = shell_out("#{which("arp")} -an")
     so.stdout.lines do |line|
       if line =~ /^\S+ \((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) at ([a-fA-F0-9\:]+) on ([a-zA-Z0-9\.\:\-]+).*\[(\w+)\]/
         # MAC addr really should be normalized to include all the zeroes.
@@ -170,7 +170,7 @@ Ohai.plugin(:Network) do
     end
 
     settings = Mash.new
-    so = shell_out("sysctl net")
+    so = shell_out("#{which("sysctl")} net")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\_]+)\: (.*)/
         # should normalize names between platforms for the same settings.
@@ -182,7 +182,7 @@ Ohai.plugin(:Network) do
     network[:interfaces] = iface
 
     net_counters = Mash.new
-    so = shell_out("netstat -i -d -l -b -n")
+    so = shell_out("#{which("netstat")} -i -d -l -b -n")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>\s+([a-f0-9\:]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/ ||
           line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>(\s+)(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:Virtualization) do
   end
 
   def fusion_exists?
-    ::File.exist?("/Applications/VMware\ Fusion.app/")
+    file_exist?("/Applications/VMware\ Fusion.app/")
   end
 
   def docker_exists?

--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -45,7 +45,7 @@ Ohai.plugin(:DMI) do
     field = nil
 
     begin
-      so = shell_out("dmidecode")
+      so = shell_out(which("dmidecode"))
       # ==== EXAMPLE RECORD: ====
       # Handle 0x0000, DMI type 0, 24 bytes
       # BIOS Information

--- a/lib/ohai/plugins/docker.rb
+++ b/lib/ohai/plugins/docker.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:Docker) do
 
   def docker_info_json
     so = shell_out("docker info --format '{{json .}}'")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       return JSON.parse(so.stdout)
     end
   rescue Ohai::Exceptions::Exec

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -98,8 +98,8 @@ Ohai.plugin(:EC2) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -31,7 +31,7 @@ Ohai.plugin(:EC2) do
   require "base64"
 
   include Ohai::Mixin::Ec2Metadata
-  include Ohai::Mixin::HttpHelper
+  # include Ohai::Mixin::HttpHelper
 
   provides "ec2"
 
@@ -110,7 +110,7 @@ Ohai.plugin(:EC2) do
 
     # Even if it looks like EC2 try to connect first
     if has_ec2_xen_uuid? || has_ec2_amazon_dmi? || has_ec2_xen_dmi? || has_ec2_identifying_number?
-      return true if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+      can_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR)
     end
   end
 

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -24,7 +24,7 @@ Ohai.plugin(:Elixir) do
     # Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
     #
     # Elixir 1.2.4
-    if so.exitstatus == 0 && so.stdout =~ /^Elixir (\S*)/
+    if so.exit_status == 0 && so.stdout =~ /^Elixir (\S*)/
       elixir = Mash.new
       elixir[:version] = $1
       languages[:elixir] = elixir

--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Erlang) do
       so = shell_out("erl -eval '{ok, Ver} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), Vsn = binary:bin_to_list(Ver, {0, byte_size(Ver) - 1}), io:format(\"~s,~s,~s\", [Vsn, erlang:system_info(version), erlang:system_info(nif_version)]), halt().' -noshell")
       # Sample output:
       # 19.1,8.1,2.11
-      if so.exitstatus == 0
+      if so.exit_status == 0
         output = so.stdout.split(",")
         erlang[:version] = output[0]
         erlang[:erts_version] = output[1]
@@ -41,7 +41,7 @@ Ohai.plugin(:Erlang) do
       so = shell_out("erl +V")
       # Sample output:
       # Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 7.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         output = so.stderr.split
         if output.length >= 6
           options = output[1]

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Filesystem) do
   def find_device(name)
     %w{/dev /dev/mapper}.each do |dir|
       path = File.join(dir, name)
-      return path if File.exist?(path)
+      return path if file_exist?(path)
     end
     name
   end
@@ -244,7 +244,7 @@ Ohai.plugin(:Filesystem) do
     end
 
     # Grab any missing mount information from /proc/mounts
-    if File.exist?("/proc/mounts")
+    if file_exist?("/proc/mounts")
       mounts = ""
       # Due to https://tickets.opscode.com/browse/OHAI-196
       # we have to non-block read dev files. Ew.

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -248,7 +248,7 @@ Ohai.plugin(:Filesystem) do
       mounts = ""
       # Due to https://tickets.opscode.com/browse/OHAI-196
       # we have to non-block read dev files. Ew.
-      f = File.open("/proc/mounts")
+      f = file_open("/proc/mounts")
       loop do
 
         data = f.read_nonblock(4096)

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -40,8 +40,8 @@ Ohai.plugin(:GCE) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Go) do
     so = shell_out("go version")
     # Sample output:
     # go version go1.6.1 darwin/amd64
-    if so.exitstatus == 0 && so.stdout =~ /go(\S+)/
+    if so.exit_status == 0 && so.stdout =~ /go(\S+)/
       go = Mash.new
       go[:version] = $1
       languages[:go] = go

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Groovy) do
     so = shell_out("groovy -v")
     # Sample output:
     # Groovy Version: 2.4.6 JVM: 1.8.0_60 Vendor: Oracle Corporation OS: Mac OS X
-    if so.exitstatus == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
+    if so.exit_status == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
       groovy = Mash.new
       groovy[:version] = $1
       groovy[:jvm] = $2

--- a/lib/ohai/plugins/haskell.rb
+++ b/lib/ohai/plugins/haskell.rb
@@ -33,7 +33,7 @@ Ohai.plugin(:Haskell) do
 
       # Sample output:
       # The Glorious Glasgow Haskell Compilation System, version 7.6.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:ghc] = Mash.new
         haskell[:ghc][:version] = so.stdout.split[-1]
         haskell[:ghc][:description] = so.stdout.chomp
@@ -48,7 +48,7 @@ Ohai.plugin(:Haskell) do
 
       # Sample output:
       # The Glorious Glasgow Haskell Compilation System, version 7.6.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:ghci] = Mash.new
         haskell[:ghci][:version] = so.stdout.split[-1]
         haskell[:ghci][:description] = so.stdout.chomp
@@ -64,7 +64,7 @@ Ohai.plugin(:Haskell) do
       # Sample output:
       # cabal-install version 1.16.0.2
       # using version 1.16.0 of the Cabal library
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:cabal] = Mash.new
         haskell[:cabal][:version] = so.stdout.split("\n")[0].split[-1]
         haskell[:cabal][:description] = so.stdout.split("\n")[0].chomp
@@ -81,7 +81,7 @@ Ohai.plugin(:Haskell) do
       # Version 1.1.0, Git revision 0e9430aad55841b5ff2c6c2851f0548c16bce7cf (3540 commits) x86_64 hpack-0.13.0
       # or
       # Version 1.2.0 x86_64 hpack-0.14.0
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:stack] = Mash.new
         haskell[:stack][:version] = /Version ([^\s,]*)/.match(so.stdout)[1] rescue nil
         haskell[:stack][:description] = so.stdout.chomp

--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -20,6 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    init_package File.exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
+    init_package file_exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
   end
 end

--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -20,6 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    init_package file_exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
+    init_package file_exist?("/proc/1/comm") ? file_open("/proc/1/comm").gets.chomp : "init"
   end
 end

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Java) do
     # java version "1.8.0_60"
     # Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
     # Java HotSpot(TM) 64-Bit Server VM (build 25.60-b23, mixed mode)
-    if so.exitstatus == 0
+    if so.exit_status == 0
       java = Mash.new
       so.stderr.split(/\r?\n/).each do |line|
         case line

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,7 +21,7 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   def get_java_info
-    so = shell_out("java -mx64m -version")
+    so = shell_out("#{which("java")} -mx64m -version")
     # Sample output:
     # java version "1.8.0_60"
     # Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
@@ -63,11 +63,11 @@ Ohai.plugin(:Java) do
   # workaround for this particular annoyance.
   def has_real_java?
     return true unless on_darwin?
-    shell_out("/usr/libexec/java_home").status.success?
+    shell_out("/usr/libexec/java_home").exit_status == 0
   end
 
   def on_darwin?
-    RUBY_PLATFORM.downcase.include?("darwin")
+    collect_os == "darwin"
   end
 
   collect_data do

--- a/lib/ohai/plugins/joyent.rb
+++ b/lib/ohai/plugins/joyent.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Joyent) do
   depends "os", "platform", "virtualization"
 
   def collect_product_file
-    data = ::File.read("/etc/product") rescue nil
+    data = file_read("/etc/product") rescue nil
     if data
       data.strip.split("\n")
     else
@@ -34,7 +34,7 @@ Ohai.plugin(:Joyent) do
   end
 
   def collect_pkgsrc
-    data = ::File.read("/opt/local/etc/pkg_install.conf") rescue nil
+    data = file_read("/opt/local/etc/pkg_install.conf") rescue nil
     if data
       /PKG_PATH=(.*)/.match(data)[1] rescue nil
     end

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -196,6 +196,11 @@ Ohai.plugin(:Kernel) do
 
     modules = Mash.new
     so = shell_out("env lsmod")
+    # NOTE: I don't know that this is right alternative on every linux platform.
+    if so.stdout == ""
+      so = shell_out("/sbin/lsmod")
+    end
+    
     so.stdout.lines do |line|
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { size: $2, refcount: $3 }

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -200,8 +200,8 @@ Ohai.plugin(:Kernel) do
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { size: $2, refcount: $3 }
         # Making sure to get the module version that has been loaded
-        if File.exist?("/sys/module/#{$1}/version")
-          version = File.read("/sys/module/#{$1}/version").chomp.strip
+        if file_exist?("/sys/module/#{$1}/version")
+          version = file_read("/sys/module/#{$1}/version").chomp.strip
           modules[$1]["version"] = version unless version.empty?
         end
       end
@@ -226,7 +226,7 @@ Ohai.plugin(:Kernel) do
     so = shell_out("uname -s")
     kernel[:os] = so.stdout.split($/)[0]
 
-    so = File.open("/etc/release") { |file| file.gets }
+    so = file_open("/etc/release") { |file| file.gets }
     md = /(?<update>\d.*\d)/.match(so)
     kernel[:update] = md[:update] if md
 

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -196,9 +196,9 @@ Ohai.plugin(:Kernel) do
 
     modules = Mash.new
     so = shell_out("env lsmod")
-    # NOTE: I don't know that this is right alternative on every linux platform.
+    
     if so.stdout == ""
-      so = shell_out("/sbin/lsmod")
+      so = shell_out(which("lsmod"))
     end
     
     so.stdout.lines do |line|

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -20,23 +20,23 @@ Ohai.plugin(:BlockDevice) do
   provides "block_device"
 
   collect_data(:linux) do
-    if File.exist?("/sys/block")
+    if file_exist?("/sys/block")
       block = Mash.new
-      Dir["/sys/block/*"].each do |block_device_dir|
+      files_in_dir["/sys/block/*"].each do |block_device_dir|
         dir = File.basename(block_device_dir)
         block[dir] = Mash.new
         %w{size removable}.each do |check|
-          if File.exist?("/sys/block/#{dir}/#{check}")
+          if file_exist?("/sys/block/#{dir}/#{check}")
             File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{model rev state timeout vendor queue_depth}.each do |check|
-          if File.exist?("/sys/block/#{dir}/device/#{check}")
+          if file_exist?("/sys/block/#{dir}/device/#{check}")
             File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{rotational physical_block_size logical_block_size}.each do |check|
-          if File.exist?("/sys/block/#{dir}/queue/#{check}")
+          if file_exist?("/sys/block/#{dir}/queue/#{check}")
             File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:BlockDevice) do
   collect_data(:linux) do
     if file_exist?("/sys/block")
       block = Mash.new
-      files_in_dir["/sys/block/*"].each do |block_device_dir|
+      files_in_dir("/sys/block/*").each do |block_device_dir|
         dir = File.basename(block_device_dir)
         block[dir] = Mash.new
         %w{size removable}.each do |check|

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -27,17 +27,17 @@ Ohai.plugin(:BlockDevice) do
         block[dir] = Mash.new
         %w{size removable}.each do |check|
           if file_exist?("/sys/block/#{dir}/#{check}")
-            File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{model rev state timeout vendor queue_depth}.each do |check|
           if file_exist?("/sys/block/#{dir}/device/#{check}")
-            File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{rotational physical_block_size logical_block_size}.each do |check|
           if file_exist?("/sys/block/#{dir}/queue/#{check}")
-            File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
       end

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:LSB) do
   collect_data(:linux) do
     lsb Mash.new
 
-    if File.exist?("/usr/bin/lsb_release")
+    if file_exist?("/usr/bin/lsb_release")
       # From package redhat-lsb on Fedora/Redhat, lsb-release on Debian/Ubuntu
       so = shell_out("lsb_release -a")
       so.stdout.lines do |line|
@@ -39,7 +39,7 @@ Ohai.plugin(:LSB) do
           lsb[:id] = line
         end
       end
-    elsif File.exist?("/etc/lsb-release")
+    elsif file_exist?("/etc/lsb-release")
       # Old, non-standard Debian support
       File.open("/etc/lsb-release").each do |line|
         case line

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:LSB) do
       end
     elsif file_exist?("/etc/lsb-release")
       # Old, non-standard Debian support
-      File.open("/etc/lsb-release").each do |line|
+      file_open("/etc/lsb-release").each do |line|
         case line
         when /^DISTRIB_ID=["']?(.+?)["']?$/
           lsb[:id] = $1

--- a/lib/ohai/plugins/linux/machineid.rb
+++ b/lib/ohai/plugins/linux/machineid.rb
@@ -22,10 +22,10 @@ Ohai.plugin(:Machineid) do
   collect_data(:linux) do
     mid = nil
 
-    if ::File.exist?("/etc/machine-id")
-      mid = ::File.read("/etc/machine-id").chomp
-    elsif ::File.exist?("/var/lib/dbus/machine-id")
-      mid = ::File.read("/var/lib/dbus/machine-id").chomp
+    if file_exist?("/etc/machine-id")
+      mid = file_read("/etc/machine-id").chomp
+    elsif file_exist?("/var/lib/dbus/machine-id")
+      mid = file_read("/var/lib/dbus/machine-id").chomp
     end
 
     if mid

--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:Mdadm) do
 
   collect_data(:linux) do
     # gather a list of all raid arrays
-    if File.exist?("/proc/mdstat")
+    if file_exist?("/proc/mdstat")
       devices = {}
       File.open("/proc/mdstat").each do |line|
         if line =~ /(md[0-9]+)/

--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -55,7 +55,7 @@ Ohai.plugin(:Mdadm) do
     # gather a list of all raid arrays
     if file_exist?("/proc/mdstat")
       devices = {}
-      File.open("/proc/mdstat").each do |line|
+      file_open("/proc/mdstat").each do |line|
         if line =~ /(md[0-9]+)/
           device = Regexp.last_match[1]
           pieces = line.split(/\s+/)

--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Memory) do
     memory[:hugepages] = Mash.new
     memory[:directmap] = Mash.new
 
-    File.open("/proc/meminfo").each do |line|
+    file_open("/proc/meminfo").each do |line|
       case line
       when /^MemTotal:\s+(\d+) (.+)$/
         memory[:total] = "#{$1}#{$2}"

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Network) do
   end
 
   def ipv6_enabled?
-    File.exist? "/proc/net/if_inet6"
+    file_exist? "/proc/net/if_inet6"
   end
 
   def ethtool_binary_path

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -42,11 +42,11 @@ Ohai.plugin(:Network) do
   end
 
   def is_openvz?
-    @openvz ||= ::File.directory?("/proc/vz")
+    @openvz ||= file_exist?("/proc/vz")
   end
 
   def is_openvz_host?
-    is_openvz? && ::File.directory?("/proc/bc")
+    is_openvz? && file_exist?("/proc/bc")
   end
 
   def extract_neighbors(family, iface, neigh_attr)

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -50,7 +50,7 @@ Ohai.plugin(:Network) do
   end
 
   def extract_neighbors(family, iface, neigh_attr)
-    so = shell_out("ip -f #{family[:name]} neigh show")
+    so = shell_out("#{which("ip")} -f #{family[:name]} neigh show")
     so.stdout.lines do |line|
       if line =~ /^([a-f0-9\:\.]+)\s+dev\s+([^\s]+)\s+lladdr\s+([a-fA-F0-9\:]+)/
         interface = iface[$2]
@@ -73,7 +73,7 @@ Ohai.plugin(:Network) do
   # 3) and since we're at it, let's populate some :routes attributes
   # (going to do that for both inet and inet6 addresses)
   def check_routing_table(family, iface, default_route_table)
-    so = shell_out("ip -o -f #{family[:name]} route show table #{default_route_table}")
+    so = shell_out("#{which("ip")} -o -f #{family[:name]} route show table #{default_route_table}")
     so.stdout.lines do |line|
       line.strip!
       logger.trace("Plugin Network: Parsing #{line}")
@@ -202,7 +202,7 @@ Ohai.plugin(:Network) do
 
   # determine link stats, vlans, queue length, and state for an interface using ip
   def link_statistics(iface, net_counters)
-    so = shell_out("ip -d -s link")
+    so = shell_out("#{which("ip")} -d -s link")
     tmp_int = nil
     on_rx = true
     so.stdout.lines do |line|
@@ -305,7 +305,7 @@ Ohai.plugin(:Network) do
   end
 
   def parse_ip_addr(iface)
-    so = shell_out("ip addr")
+    so = shell_out("#{which("ip")} addr")
     cint = nil
     so.stdout.lines do |line|
       cint = match_iproute(iface, line, cint)

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -22,16 +22,21 @@ Ohai.plugin(:Virtualization) do
   require "ohai/mixin/dmi_decode"
   include Ohai::Mixin::DmiDecode
 
+  # TODO: A series of expensive operations are about to begin
+  #   This which operation will look through all the possible paths
+  #   and when it is done it returns the same name back if it can't find it
+  #   
+    
   def lxc_version_exists?
-    which("lxc-version") || which("lxc-start")
+    which("lxc-version") != "lxc-version" || which("lxc-start") != "lxc-start"
   end
 
   def nova_exists?
-    which("nova")
+    which("nova") != "nova"
   end
 
   def docker_exists?
-    which("docker")
+    which("docker") != "docker"
   end
 
   collect_data(:linux) do

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Lua) do
     so = shell_out("lua -v")
     # Sample output:
     # Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
-    if so.exitstatus == 0
+    if so.exit_status == 0
       lua = Mash.new
       # at some point in lua's history they went from outputting the version
       # on stderr to doing it on stdout. This handles old / new versions

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Mono) do
     # 	Misc:          softtrace
     # 	LLVM:          supported, not enabled.
     # 	GC:            sgen
-    if so.exitstatus == 0
+    if so.exit_status == 0
       mono = Mash.new
       output = so.stdout.split
       mono[:version] = output[4] unless output[4].nil?

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Nodejs) do
     so = shell_out("node -v")
     # Sample output:
     # v5.10.1
-    if so.exitstatus == 0
+    if so.exit_status == 0
       nodejs = Mash.new
       output = so.stdout.split
       if output.length >= 1

--- a/lib/ohai/plugins/ohai.rb
+++ b/lib/ohai/plugins/ohai.rb
@@ -24,5 +24,32 @@ Ohai.plugin(:Ohai) do
     chef_packages[:ohai] = Mash.new
     chef_packages[:ohai][:version] = Ohai::VERSION
     chef_packages[:ohai][:ohai_root] = Ohai::OHAI_ROOT
+
+        # welcome to a quick implementation that gets the job done.
+
+    # Try and find chef. If it results in returning us chef its not on the path
+    # So we want to look for it in the usual install locations.
+    ohai_bin = which('ohai') 
+    if ohai_bin == 'ohai'
+      if file_exist?('/opt/chef/bin/ohai')
+        ohai_bin = '/opt/chef/bin/ohai'
+      elsif file_exist?('/opt/chefdk/bin/ohai')
+        ohai_bin = '/opt/chefdk/bin/ohai'
+      end
+    end
+
+    if ohai_bin != 'ohai'
+      ohai_app_name, version = shell_out("#{ohai_bin} --version").stdout.chomp.split(' ')
+
+      chef_packages Mash.new unless chef_packages
+      chef_packages[:ohai] = Mash.new
+      chef_packages[:ohai][:version] = version
+
+      # There is an assumption that it exists somewhere within this directory.
+      # There could multiple and I'm not sure which one would be prefered. I honestly would
+      # just put them all into the value here in an array.
+      ohai_root = shell_out("find /opt -path '*/ohai-#{version}/lib'").stdout.chomp.lines.first
+      chef_packages[:ohai][:ohai_root] = ohai_root
+    end
   end
 end

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -1,13 +1,7 @@
 
 Ohai.plugin(:Passwd) do
-  require "etc"
   provides "etc", "current_user"
   optional true
-
-  def fix_encoding(str)
-    str.force_encoding(Encoding.default_external) if str.respond_to?(:force_encoding)
-    str
-  end
 
   collect_data do
     unless etc
@@ -16,23 +10,20 @@ Ohai.plugin(:Passwd) do
       etc[:passwd] = Mash.new
       etc[:group] = Mash.new
 
-      Etc.passwd do |entry|
-        user_passwd_entry = Mash.new(dir: entry.dir, gid: entry.gid, uid: entry.uid, shell: entry.shell, gecos: entry.gecos)
-        user_passwd_entry.each_value { |v| fix_encoding(v) }
-        entry_name = fix_encoding(entry.name)
-        etc[:passwd][entry_name] = user_passwd_entry unless etc[:passwd].key?(entry_name)
+      file_read('/etc/passwd').lines.each do |line|
+        name, has_password, uid, gid, gecos, dir, shell = line.strip.split(':')
+        user_passwd_entry = Mash.new(dir: dir, gid: gid, uid: uid, shell: shell, gecos: gecos)
+        etc[:passwd][name] = user_passwd_entry unless etc[:passwd].key?(name)
       end
 
-      Etc.group do |entry|
-        group_entry = Mash.new(gid: entry.gid,
-                               members: entry.mem.map { |u| fix_encoding(u) })
-
-        etc[:group][fix_encoding(entry.name)] = group_entry
+      file_read('/etc/group').lines.each do |line|
+        name, has_password, gid, members = line.strip.split(':')
+        etc[:group][name] = Mash.new(gid: gid, members: members.to_s.split(","))
       end
     end
 
     unless current_user
-      current_user fix_encoding(Etc.getpwuid(Process.euid).name)
+      current_user shell_out('whoami').stdout.chomp
     end
   end
 

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Perl) do
     # Sample output:
     # version='5.18.2';
     # archname='darwin-thread-multi-2level';
-    if so.exitstatus == 0
+    if so.exit_status == 0
       perl = Mash.new
       so.stdout.split(/\r?\n/).each do |line|
         case line

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:PHP) do
     # PHP 5.5.31 (cli) (built: Feb 20 2016 20:33:10)
     # Copyright (c) 1997-2015 The PHP Group
     # Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies
-    if so.exitstatus == 0
+    if so.exit_status == 0
       php = Mash.new
       so.stdout.each_line do |line|
         case line

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Powershell) do
     # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
     # PSRemotingProtocolVersion      2.2
 
-    if so.exitstatus == 0
+    if so.exit_status == 0
       powershell = Mash.new
       version_info = {}
       so.stdout.strip.each_line do |line|

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Python) do
     # Sample output:
     # 2.7.11 (default, Dec 26 2015, 17:47:53)
     # [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
-    if so.exitstatus == 0
+    if so.exit_status == 0
       python = Mash.new
       output = so.stdout.split
       python[:version] = output[0]

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Rackspace) do
   # false:: Otherwise
   def has_rackspace_metadata?
     so = shell_out("xenstore-read vm-data/provider_data/provider")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.strip.casecmp("rackspace") == 0
     end
   rescue Ohai::Exceptions::Exec
@@ -99,7 +99,7 @@ Ohai.plugin(:Rackspace) do
   #
   def get_region
     so = shell_out("xenstore-ls vm-data/provider_data")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.split("\n").each do |line|
         rackspace[:region] = line.split[2].delete('\"') if line =~ /^region/
       end
@@ -113,7 +113,7 @@ Ohai.plugin(:Rackspace) do
   #
   def get_instance_id
     so = shell_out("xenstore-read name")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       rackspace[:instance_id] = so.stdout.gsub(/instance-/, "")
     end
   rescue Ohai::Exceptions::Exec
@@ -125,11 +125,11 @@ Ohai.plugin(:Rackspace) do
   #
   def get_private_networks
     so = shell_out("xenstore-ls vm-data/networking")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       networks = []
       so.stdout.split("\n").map { |l| l.split("=").first.strip }.map do |item|
         so = shell_out("xenstore-read vm-data/networking/#{item}")
-        if so.exitstatus == 0
+        if so.exit_status == 0
           networks.push(FFI_Yajl::Parser.new.parse(so.stdout))
         else
           logger.trace("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")

--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -67,7 +67,7 @@ Ohai.plugin(:Ruby) do
                     run_ruby("require 'rubygems'; puts ::Gem.default_exec_format % 'gem'"),
                     "gem",
                    ].map { |bin| ::File.join(bin_dir, bin) }
-    gem_binary = gem_binaries.find { |bin| ::File.exist? bin }
+    gem_binary = gem_binaries.find { |bin| file_exist? bin }
     if gem_binary
       languages[:ruby][:gems_dir] = run_ruby "puts %x{#{ruby_bin} #{gem_binary} env gemdir}.chomp!"
       languages[:ruby][:gem_bin] = gem_binary

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Rust) do
     so = shell_out("rustc --version")
     # Sample output:
     # rustc 1.7.0
-    if so.exitstatus == 0
+    if so.exit_status == 0
       rust = Mash.new
       rust[:version] = so.stdout.split[1]
       languages[:rust] = rust if rust[:version]

--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Scala) do
       # Sample output:
       # cat: /release: No such file or directory
       # Scala code runner version 2.12.1 -- Copyright 2002-2016, LAMP/EPFL and Lightbend, Inc.
-      if so.exitstatus == 0
+      if so.exit_status == 0
         scala[:version] = so.stderr.match(/.*version (\S*)/)[1]
       end
     rescue Ohai::Exceptions::Exec

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Scaleway) do
   # looks for `scaleway` keyword in kernel command line
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
-    if ::File.read("/proc/cmdline") =~ /scaleway/
+    if file_read("/proc/cmdline") =~ /scaleway/
       logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end

--- a/lib/ohai/plugins/shells.rb
+++ b/lib/ohai/plugins/shells.rb
@@ -20,9 +20,9 @@ Ohai.plugin(:Shells) do
   provides "shells"
 
   collect_data do
-    if ::File.exist?("/etc/shells")
+    if file_exist?("/etc/shells")
       shells []
-      ::File.readlines("/etc/shells").each do |line|
+      file_readlines("/etc/shells").each do |line|
         # remove carriage returns and skip over comments / empty lines
         shells << line.chomp if line[0] == "/"
       end

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_build", "platform_family"
 
   collect_data(:solaris2) do
-    if File.exist?("/sbin/uname")
+    if file_exist?("/sbin/uname")
       uname_exec = "/sbin/uname"
     else
       uname_exec = "uname"

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Platform) do
       end
     end
 
-    File.open("/etc/release") do |file|
+    file_open("/etc/release") do |file|
       while ( line = file.gets )
         case line
         when /^.*(SmartOS).*$/

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Virtualization) do
 
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     psrinfo_path = Ohai.abs_path( "/usr/sbin/psrinfo" )
-    if File.exist?(psrinfo_path)
+    if file_exist?(psrinfo_path)
       so = shell_out("#{psrinfo_path} -pv")
       if so.stdout =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
         virtualization[:system] = "kvm"

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][guest.to_sym] = "guest"
     end
 
-    if File.executable?("/usr/sbin/zoneadm")
+    if file_executable?("/usr/sbin/zoneadm")
       zones = Mash.new
       so = shell_out("zoneadm list -pc")
       so.stdout.lines do |line|

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -38,9 +38,9 @@ Ohai.plugin(:SSHHostKey) do
   collect_data do
     keys[:ssh] = Mash.new
 
-    sshd_config = if File.exist?("/etc/ssh/sshd_config")
+    sshd_config = if file_exist?("/etc/ssh/sshd_config")
                     "/etc/ssh/sshd_config"
-                  elsif File.exist?("/etc/sshd_config")
+                  elsif file_exist?("/etc/sshd_config")
                     # Darwin
                     "/etc/sshd_config"
                   else
@@ -62,21 +62,21 @@ Ohai.plugin(:SSHHostKey) do
       end
     end
 
-    if keys[:ssh][:host_dsa_public].nil? && File.exist?("/etc/ssh/ssh_host_dsa_key.pub")
+    if keys[:ssh][:host_dsa_public].nil? && file_exist?("/etc/ssh/ssh_host_dsa_key.pub")
       keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_rsa_public].nil? && File.exist?("/etc/ssh/ssh_host_rsa_key.pub")
+    if keys[:ssh][:host_rsa_public].nil? && file_exist?("/etc/ssh/ssh_host_rsa_key.pub")
       keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_ecdsa_public].nil? && File.exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
+    if keys[:ssh][:host_ecdsa_public].nil? && file_exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
       content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
     end
 
-    if keys[:ssh][:host_ed25519_public].nil? && File.exist?("/etc/ssh/ssh_host_ed25519_key.pub")
+    if keys[:ssh][:host_ed25519_public].nil? && file_exist?("/etc/ssh/ssh_host_ed25519_key.pub")
       keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:SSHHostKey) do
         conf.each_line do |line|
           if line =~ /^hostkey\s/i
             pub_file = "#{line.split[1]}.pub"
-            content = IO.read(pub_file).split
+            content = file_read(pub_file).split
             key_type, key_subtype = extract_keytype?(content)
             keys[:ssh]["host_#{key_type}_public"] = content[1] unless key_type.nil?
             keys[:ssh]["host_#{key_type}_type"] = key_subtype unless key_subtype.nil?
@@ -63,21 +63,21 @@ Ohai.plugin(:SSHHostKey) do
     end
 
     if keys[:ssh][:host_dsa_public].nil? && file_exist?("/etc/ssh/ssh_host_dsa_key.pub")
-      keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
+      keys[:ssh][:host_dsa_public] = file_read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
     end
 
     if keys[:ssh][:host_rsa_public].nil? && file_exist?("/etc/ssh/ssh_host_rsa_key.pub")
-      keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
+      keys[:ssh][:host_rsa_public] = file_read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
     end
 
     if keys[:ssh][:host_ecdsa_public].nil? && file_exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
-      content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
+      content = file_read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
     end
 
     if keys[:ssh][:host_ed25519_public].nil? && file_exist?("/etc/ssh/ssh_host_ed25519_key.pub")
-      keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
+      keys[:ssh][:host_ed25519_public] = file_read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end
 end

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -49,7 +49,7 @@ Ohai.plugin(:SSHHostKey) do
                   end
 
     if sshd_config
-      File.open(sshd_config) do |conf|
+      file_open(sshd_config) do |conf|
         conf.each_line do |line|
           if line =~ /^hostkey\s/i
             pub_file = "#{line.split[1]}.pub"

--- a/lib/ohai/plugins/sysconf.rb
+++ b/lib/ohai/plugins/sysconf.rb
@@ -24,7 +24,7 @@ Ohai.plugin(:Sysconf) do
     if getconf_path
       getconf = shell_out("#{getconf_path} -a")
 
-      if getconf.exitstatus == 0
+      if getconf.exit_status == 0
         sysconf Mash.new unless sysconf
 
         getconf.stdout.split("\n").each do |line|

--- a/lib/ohai/plugins/timezone.rb
+++ b/lib/ohai/plugins/timezone.rb
@@ -19,6 +19,12 @@ Ohai.plugin(:Timezone) do
 
   collect_data(:default) do
     time Mash.new unless time
+    logger.warn('Collecting time locally and not remotely')
     time[:timezone] = Time.now.getlocal.zone
+  end
+
+  collect_data(:linux) do
+    time Mash.new unless time
+    time[:timezone] = shell_out('date +%Z').stdout.chomp
   end
 end

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:Uptime) do
   end
 
   collect_data(:linux) do
-    uptime, idletime = File.open("/proc/uptime").gets.split(" ")
+    uptime, idletime = file_open("/proc/uptime").gets.split(" ")
     uptime_seconds uptime.to_i
     uptime seconds_to_human(uptime.to_i)
     idletime_seconds idletime.to_i

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:Virtualbox) do
 
     so = shell_out("VBoxControl guestproperty enumerate")
 
-    if so.exitstatus == 0
+    if so.exit_status == 0
       virtualbox Mash.new
       virtualbox[:host] = Mash.new
       virtualbox[:guest] = Mash.new

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:VMware) do
   end
 
   def get_vm_attributes(vmtools_path)
-    if !File.exist?(vmtools_path)
+    if !file_exist?(vmtools_path)
       logger.trace("Plugin VMware: #{vmtools_path} not found")
     else
       vmware Mash.new

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -198,7 +198,7 @@ Ohai.plugin(:Network) do
 
     cint = nil
     so = shell_out("arp -a")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.lines do |line|
         if line =~ /^Interface:\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+[-]+\s+(0x\S+)/
           cint = $2.downcase

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -51,13 +51,13 @@ module Ohai
             raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin version #{plugin.version} for plugin #{plugin}"
           end
         rescue Ohai::Exceptions::Error # rubocop: disable Lint/ShadowedException
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           raise
         rescue SystemExit # abort or exit from plug-in should exit Ohai with failure code
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           raise
         rescue Exception, Errno::ENOENT => e
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -51,10 +51,13 @@ module Ohai
             raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin version #{plugin.version} for plugin #{plugin}"
           end
         rescue Ohai::Exceptions::Error # rubocop: disable Lint/ShadowedException
+          require 'pry' ; binding.pry
           raise
         rescue SystemExit # abort or exit from plug-in should exit Ohai with failure code
+          require 'pry' ; binding.pry
           raise
         rescue Exception, Errno::ENOENT => e
+          require 'pry' ; binding.pry
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -88,7 +88,10 @@ module Ohai
         end
 
         if dependency_providers.empty?
+          # TODO: assigning the backend to the data of the plugin.
+          #   is probably not the best approach but it was an easy spot to start.
           next_plugin.data[:backend] = backend
+          # require 'pry' ; binding.pry
           @safe_run ? next_plugin.safe_run : next_plugin.run
           next_plugin.data[:backend] = nil
           if next_plugin.failed

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -110,11 +110,21 @@ module Ohai
           Train.create('docker', host: host)
         elsif config[:target].to_s.start_with?('ssh')
           # ssh://user:password@host:port
+          # TODO: This has already been written within inspec. It would be
+          #   best to use that code.
           user_pass, host_port = config[:target].gsub('ssh://','').split('@')
+          user, pass = user_pass.split(':')
           host, port = host_port.split(':')
-          # require 'pry' ; binding.pry
+
+          train_config = {
+            host: host,
+            port: port,
+            user: user,
+            password: password
+            key_files = config[:keyfile]
+          }
           
-          Train.create('ssh',host: host, port: port || 22, user: user_pass, key_files: '~/.ssh/ohai.pem')
+          Train.create('ssh',train_config)
         else
           fail 'unsupported target'
         end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -144,8 +144,13 @@ module Ohai
           
         @provides_map.all_plugins(attribute_filter).each do |plugin|
           # This is a good place to use the train connection to
-          # execute a command or look at a file
+          # execute a command or look at a file.
+          # If you run ohai with a particular plugin in mind it makes 
+          # it easier to troubleshoot:
+          #
+          # plugin.data[:backend] = conn
           # require 'pry' ; binding.pry
+          # plugin.run_plugin
           @runner.run_plugin(plugin, conn)
         end
         conn.close

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -120,10 +120,10 @@ module Ohai
             host: host,
             port: port,
             user: user,
-            password: password
-            key_files = config[:keyfile]
+            password: pass,
+            key_files: config[:keyfiles]
           }
-          
+
           Train.create('ssh',train_config)
         else
           fail 'unsupported target'
@@ -148,6 +148,7 @@ module Ohai
         conn.close
 
       rescue Ohai::Exceptions::AttributeNotFound, Ohai::Exceptions::DependencyCycle => e
+        require 'pry' ; binding.pry
         logger.error("Encountered error while running plugins: #{e.inspect}")
         raise
       end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -143,6 +143,9 @@ module Ohai
         conn = backend.connection
           
         @provides_map.all_plugins(attribute_filter).each do |plugin|
+          # This is a good place to use the train connection to
+          # execute a command or look at a file
+          # require 'pry' ; binding.pry
           @runner.run_plugin(plugin, conn)
         end
         conn.close

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -151,7 +151,7 @@ module Ohai
         conn.close
 
       rescue Ohai::Exceptions::AttributeNotFound, Ohai::Exceptions::DependencyCycle => e
-        require 'pry' ; binding.pry
+        # require 'pry' ; binding.pry
         logger.error("Encountered error while running plugins: #{e.inspect}")
         raise
       end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
   s.add_dependency "chef-config", ">= 12.8", "< 16"
+  s.add_dependency "train", ">= 2.0.2"
   # Note for ohai developers: If chef-config causes you grief, try:
   #     bundle install --with development
   # this should work as long as chef is a development dependency in Gemfile.


### PR DESCRIPTION
## LINUX - Centos 6 Running in AWS

Running the command

```bash
$ bin/ohai --target ssh://centos@IPADDRESS -i ~/.ssh/ohai.pem
```

### Plugins

Need to fix the following plugin discrepancies.

- [x] `languages`
- [x] `uptime`
- [x] `counters` is empty
- [x] `network` is empty
- [x] `virtualization` missing `"xen": "guest"`
- [x] `packages`
- [x] `sysconf` is missing
- [x] `filesystem` 
- [x] `dmi` is missing `"dmidecode_version": "2.12"`
- [x] `keys/ssh`
- [x] `block_device`
- [x] `etc` is pulling in some local entries (e.g. `_appleevents` appearing in a centos target)
- [x] `root_group` is collecting data locally
- [x] `current_user` is collecting data locally
- [x] `time/timezone` is collecting data locally
- [x] `ec2` is missing and that is because the `lib/mixin/ec2_metadata` assumes the code is run locally and performs an HTTP from the local instance to the IP only available remotely. It seems like it could be replaced with some rudimentary curling and relying on exit status.
- [x] `cloud` is null because it is dependent on ec2
- [x] `json?` attribute missing something `"{\n  \"devpayProductCodes\" : null....region\" : \"us-east-1\"\n}",
- [x] `virtualization/systems/docker` is reporting 'host' when normally it is absent
- [x] `virtualization/systems/openstack` is reporting 'host' when normally it is absent
- [x] `virtualization/system` is reporting 'openstack' when normally it is 'xen'
- [x] `virtualization/role` is reporting 'host' when normally it is 'guest'
- [ ] `docker` key is present and empty when it is usually absent from the results (this is minor)
- [x] `memory/directmap` is found when executed remotely but not locally - turns out that is just not in the version of ohai running on the system.
- [x] `chef_packages` is collecting data locally and using `require 'chef/version'` to get to that information causing an exception to be raised (this currently pauses the execution)

### Performance

*Running Locally* with Ohai 14.8.10 (2 seconds)
```
real	0m1.492s
user	0m0.523s
sys	0m0.257s
```
*Running remotely* with this Ohai (2 minutes)
```
2.35s user 0.50s system 2% cpu 2:01.49 total
```