### PR TITLE
Adds target support for ubuntu over SSH in ec2

### DIFF
--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -61,6 +61,14 @@ class Ohai::Application
     long: "--target TARGET",
     description: "Target a remote location to invoke Ohai",
     on: :on
+  
+  # NOTE: This cli library does not support multiple parameters making
+  #   this not paralleled by what is offered by inspec.
+  option :keyfiles,
+    short: "-i TARGET",
+    long: "--key-file=KEYFILE",
+    description: "Login key or certificate file for a remote scan.",
+    on: :on
 
   option :help,
     short: "-h",

--- a/lib/ohai/application.rb
+++ b/lib/ohai/application.rb
@@ -56,6 +56,12 @@ class Ohai::Application
     description: "Set the log file location, defaults to STDOUT - recommended for daemonizing",
     proc: nil
 
+  option :target,
+    short: "-t TARGET",
+    long: "--target TARGET",
+    description: "Target a remote location to invoke Ohai",
+    on: :on
+
   option :help,
     short: "-h",
     long: "--help",
@@ -90,7 +96,6 @@ class Ohai::Application
   def configure_ohai
     @attributes = parse_options
     @attributes = nil if @attributes.empty?
-
     load_workstation_config
 
     Ohai::Log.init(Ohai.config[:log_location])

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -133,6 +133,23 @@ module Ohai
         data[:backend].file(filename).exist?
       end
 
+      # This is to provide a replacement for `File.open`
+      # returning a stringio gets you support for `gets` `lines`
+      # taking the block brings it on par with `File.open` use of block
+      def file_open(filename)
+        file_object = StringIO.new data[:backend].file(filename)
+        yield file_object if block_given?
+        file_object
+      end
+
+      # This is to provide a replacement for `File.executable?`
+      def file_executable?(filename)
+        binding.require 'pry' ; binding.pry
+        data[:backend].file(filename)
+        puts "Currently this may work"
+        true
+      end
+
       # This is to provide a replacement for `File.read`
       def file_read(filename)
         data[:backend].file(filename).content

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -128,6 +128,7 @@ module Ohai
 
       # This is to provide a replacement for `File.exist?`
       def file_exist?(filename)
+        # require 'pry' ; binding.pry
         data[:backend].file(filename).exist?
       end
 
@@ -142,7 +143,7 @@ module Ohai
 
       # This is to provide a replacement for `File.executable?`
       def file_executable?(filename)
-        binding.require 'pry' ; binding.pry
+        # require 'pry' ; binding.pry
         data[:backend].file(filename)
         puts "Currently this may work"
         true
@@ -150,6 +151,7 @@ module Ohai
 
       # This is to provide a replacement for `File.read`
       def file_read(filename)
+        # require 'pry' ; binding.pry
         data[:backend].file(filename).content
       end
 

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -106,9 +106,8 @@ module Ohai
       # include Ohai::Util::FileHelper
       # This mixin is replaced currently with this method.
       def which(cmd)
-        # require 'pry' ; binding.pry
         # paths = ENV["PATH"].split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
-        paths = data[:backend].run_command("echo $PATH").split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
+        paths = data[:backend].run_command("echo $PATH").stdout.split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]
         paths.each do |path|
           filename = File.join(path, cmd)
           
@@ -116,10 +115,9 @@ module Ohai
           #   At the moment I don't know how to get the current user (local and remote)
 
           # find the file stats => mode => convert to octal
-          backend_file_mode = data[:backend].file(filename).stat.mode
-
+          backend_file_mode = data[:backend].file(filename).stat[:mode]
           # if File.executable?(filename)
-          if backend_file_mode.to_s(8) == "755"
+          if backend_file_mode.to_i.to_s(8) == "755"
             logger.trace("Plugin #{name}: found #{cmd} at #{filename}")
             return filename
           end

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -120,6 +120,7 @@ module Ohai
         #   what we want is linux - at least that is what I believe is suppose
         #   to be the os value for the plugins to match on the collect_data blocks
         found_os = data[:backend].os[:family_hierarchy].find { |family| __collect_os(family) }
+        
         # require 'pry' ; binding.pry
         if found_os.nil?
           require 'pry' ; binding.pry
@@ -132,7 +133,7 @@ module Ohai
       # This mixin is replaced currently with this method.
       def shell_out(cmd, **options)
         # require 'pry' ; binding.pry
-        logger.info("Running: #{cmd}")
+        # logger.info("Running: #{cmd}")
         result = data[:backend].run_command(cmd)
         result
       end
@@ -149,7 +150,7 @@ module Ohai
       def which(cmd)
         # require 'pry' ; binding.pry
 
-        # TODO: the interface here is poor it returns the cmd back when it fails to find
+        # TODO: the interface here is poor it returns a nil if it fails to find
         #   a full path. On success it returns the full path.
         #
         #   Perhaps:
@@ -193,10 +194,7 @@ module Ohai
           end
         end
         logger.warn("Plugin #{name}: did not find #{cmd}")
-        # NOTE this was a poor interface - originally this returned a filename or false
-        #  I have changed it to return the same command that it was given and that will
-        #  likely result in no data collected but at least a well-formed command
-        cmd
+        nil
       end
 
       # This is to provide a replacement for `File.exist?`

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -137,6 +137,11 @@ module Ohai
         result
       end
 
+      def can_connect?(address, port = 80, timeout = 2)
+        # require 'pry' ; binding.pry
+        shell_out("curl -Is #{address}:#{port} --connect-timeout #{timeout}").exit_status == 0
+      end
+
       include Ohai::Mixin::SecondsToHuman
       
       # include Ohai::Util::FileHelper

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -137,7 +137,7 @@ module Ohai
       # returning a stringio gets you support for `gets` `lines`
       # taking the block brings it on par with `File.open` use of block
       def file_open(filename)
-        file_object = StringIO.new data[:backend].file(filename)
+        file_object = StringIO.new data[:backend].file(filename).content
         yield file_object if block_given?
         file_object
       end

--- a/lib/ohai/dsl/plugin.rb
+++ b/lib/ohai/dsl/plugin.rb
@@ -136,9 +136,13 @@ module Ohai
       # returning a stringio gets you support for `gets` `lines`
       # taking the block brings it on par with `File.open` use of block
       def file_open(filename)
-        file_object = StringIO.new data[:backend].file(filename).content
-        yield file_object if block_given?
-        file_object
+        # require 'pry' ; binding.pry
+        content = data[:backend].file(filename).content
+        # NOTE: I need to look at the interface for File.open better.
+        #   it seems with a block passed you use the content in the block
+        #   but you return an IO object.
+        yield content if block_given?
+        StringIO.new content
       end
 
       # This is to provide a replacement for `File.executable?`

--- a/lib/ohai/mixin/ec2_metadata.rb
+++ b/lib/ohai/mixin/ec2_metadata.rb
@@ -213,6 +213,17 @@ module Ohai
         response.code == "200" ? response.body : nil
       end
 
+      def json?(data)
+        data = StringIO.new(data)
+        parser = FFI_Yajl::Parser.new
+        begin
+          parser.parse(data)
+          true
+        rescue FFI_Yajl::ParseError
+          false
+        end
+      end
+
       def fetch_dynamic_data
         @fetch_dynamic_data ||= begin
           response = http_client.get("/#{best_api_version}/dynamic/instance-identity/document/")

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -47,7 +47,7 @@ Ohai.plugin(:Azure) do
   # check for either the waagent or the unknown-245 DHCP option that Azure uses
   # http://blog.mszcool.com/index.php/2015/04/detecting-if-a-virtual-machine-runs-in-microsoft-azure-linux-windows-to-protect-your-software-when-distributed-via-the-azure-marketplace/
   def has_waagent?
-    if File.exist?("/usr/sbin/waagent") || Dir.exist?('C:\WindowsAzure')
+    if file_exist?("/usr/sbin/waagent") || file_exist?('C:\WindowsAzure')
       logger.trace("Plugin Azure: Found waagent used by Azure.")
       true
     end
@@ -55,7 +55,7 @@ Ohai.plugin(:Azure) do
 
   def has_dhcp_option_245?
     has_245 = false
-    if File.exist?("/var/lib/dhcp/dhclient.eth0.leases")
+    if file_exist?("/var/lib/dhcp/dhclient.eth0.leases")
       File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")

--- a/lib/ohai/plugins/azure.rb
+++ b/lib/ohai/plugins/azure.rb
@@ -56,7 +56,7 @@ Ohai.plugin(:Azure) do
   def has_dhcp_option_245?
     has_245 = false
     if file_exist?("/var/lib/dhcp/dhclient.eth0.leases")
-      File.open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
+      file_open("/var/lib/dhcp/dhclient.eth0.leases").each do |line|
         if line =~ /unknown-245/
           logger.trace("Plugin Azure: Found unknown-245 DHCP option used by Azure.")
           has_245 = true

--- a/lib/ohai/plugins/bsd/virtualization.rb
+++ b/lib/ohai/plugins/bsd/virtualization.rb
@@ -66,7 +66,7 @@ Ohai.plugin(:Virtualization) do
     end
 
     # Detect bhyve by presence of /dev/vmm
-    if File.exist?("/dev/vmm")
+    if file_exist?("/dev/vmm")
       virtualization[:system] = "bhyve"
       virtualization[:role] = "host"
       virtualization[:systems][:bhyve] = "host"

--- a/lib/ohai/plugins/c.rb
+++ b/lib/ohai/plugins/c.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:C) do
 
   def collect(cmd, &block)
     so = shell_out(cmd)
-    if so.exitstatus == 0
+    if so.exit_status == 0
       yield(so)
     else
       logger.trace("Plugin C: '#{cmd}' failed. Skipping data.")
@@ -34,7 +34,7 @@ Ohai.plugin(:C) do
   def xcode_installed?
     logger.trace("Plugin C: Checking for Xcode Command Line Tools.")
     so = shell_out("/usr/bin/xcode-select -p")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       logger.trace("Plugin C: Xcode Command Line Tools found.")
       return true
     else
@@ -125,7 +125,7 @@ Ohai.plugin(:C) do
     # ibm xlc
 
     so = shell_out("xlc -qversion")
-    if so.exitstatus == 0 || (so.exitstatus >> 8) == 249
+    if so.exit_status == 0 || (so.exit_status >> 8) == 249
       description = so.stdout.split($/).first
       if description =~ /V(\d+\.\d+)/
         @c[:xlc] = Mash.new

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -21,6 +21,7 @@ Ohai.plugin(:Chef) do
 
   collect_data do
     begin
+      # TODO: This approach to finding the chef version will not work remotely
       require "chef/version"
     rescue Gem::LoadError
       logger.trace("Plugin Chef: Unable to load the chef gem to determine the version")

--- a/lib/ohai/plugins/chef.rb
+++ b/lib/ohai/plugins/chef.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Chef) do
     # Try and find chef. If it results in returning us chef its not on the path
     # So we want to look for it in the usual install locations.
     chef_client_bin = which('chef-client') 
-    if chef_client_bin == 'chef-client'
+    if chef_client_bin.nil?
       if file_exist?('/opt/chef/bin/chef-client')
         chef_client_bin = '/opt/chef/bin/chef-client'
       elsif file_exist?('/opt/chefdk/bin/chef-client')
@@ -33,7 +33,7 @@ Ohai.plugin(:Chef) do
       end
     end
 
-    if chef_client_bin != 'chef-client'
+    if chef_client_bin
       chef_app_name, version = shell_out("#{chef_client_bin} --version").stdout.chomp.split(' ')
 
       chef_packages Mash.new unless chef_packages

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -122,7 +122,7 @@ Ohai.plugin(:CPU) do
       begin
         logger.trace("Plugin CPU: Falling back to aggregate data from lscpu as real cpu & core data is missing in /proc/cpuinfo")
         so = shell_out("lscpu")
-        if so.exitstatus == 0
+        if so.exit_status == 0
           lscpu_data = Mash.new
           so.stdout.each_line do |line|
             case line

--- a/lib/ohai/plugins/cpu.rb
+++ b/lib/ohai/plugins/cpu.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:CPU) do
   def parse_bsd_dmesg(&block)
     cpuinfo = Mash.new
     cpuinfo["flags"] = []
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /CPU:\s+(.+) \(([\d.]+).+\)/
         cpuinfo["model_name"] = $1
@@ -53,7 +53,7 @@ Ohai.plugin(:CPU) do
     cpu_number = 0
     current_cpu = nil
 
-    File.open("/proc/cpuinfo").each do |line|
+    file_open("/proc/cpuinfo").each do |line|
       case line
       when /processor\s+:\s(.+)/
         cpuinfo[$1] = Mash.new
@@ -212,7 +212,7 @@ Ohai.plugin(:CPU) do
     # to scrape from dmesg.boot is the cpu feature list.
     # cpu0: FPU,V86,DE,PSE,TSC,MSR,MCE,CX8,SEP,MTRR,PGE,MCA,CMOV,PAT,CFLUSH,DS,ACPI,MMX,FXSR,SSE,SSE2,SS,TM,SBF,EST,TM2
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu\d+:\s+([A-Z]+$|[A-Z]+,.*$)/
         cpuinfo["flags"] = $1.downcase.split(",")
@@ -235,7 +235,7 @@ Ohai.plugin(:CPU) do
     # available instruction set
     # cpu0 at mainbus0 apid 0: Intel 686-class, 2134MHz, id 0x6f6
 
-    File.open("/var/run/dmesg.boot").each do |line|
+    file_open("/var/run/dmesg.boot").each do |line|
       case line
       when /cpu[\d\w\s]+:\s([\w\s\-]+),\s+(\w+),/
         cpuinfo[:model_name] = $1

--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -91,7 +91,7 @@ Ohai.plugin(:Network) do
     counters Mash.new unless counters
     counters[:network] = Mash.new unless counters[:network]
 
-    so = shell_out("route -n get default")
+    so = shell_out("#{which("route")} -n get default")
     so.stdout.lines do |line|
       if line =~ /(\w+): ([\w\.]+)/
         case $1
@@ -104,7 +104,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("ifconfig -a")
+    so = shell_out("#{which("ifconfig")} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)$/
@@ -159,7 +159,7 @@ Ohai.plugin(:Network) do
       end
     end
 
-    so = shell_out("arp -an")
+    so = shell_out("#{which("arp")} -an")
     so.stdout.lines do |line|
       if line =~ /^\S+ \((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) at ([a-fA-F0-9\:]+) on ([a-zA-Z0-9\.\:\-]+).*\[(\w+)\]/
         # MAC addr really should be normalized to include all the zeroes.
@@ -170,7 +170,7 @@ Ohai.plugin(:Network) do
     end
 
     settings = Mash.new
-    so = shell_out("sysctl net")
+    so = shell_out("#{which("sysctl")} net")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\_]+)\: (.*)/
         # should normalize names between platforms for the same settings.
@@ -182,7 +182,7 @@ Ohai.plugin(:Network) do
     network[:interfaces] = iface
 
     net_counters = Mash.new
-    so = shell_out("netstat -i -d -l -b -n")
+    so = shell_out("#{which("netstat")} -i -d -l -b -n")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>\s+([a-f0-9\:]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/ ||
           line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>(\s+)(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/

--- a/lib/ohai/plugins/darwin/network.rb
+++ b/lib/ohai/plugins/darwin/network.rb
@@ -91,7 +91,7 @@ Ohai.plugin(:Network) do
     counters Mash.new unless counters
     counters[:network] = Mash.new unless counters[:network]
 
-    so = shell_out("#{which("route")} -n get default")
+    so = shell_out("#{which("route") || "route"} -n get default")
     so.stdout.lines do |line|
       if line =~ /(\w+): ([\w\.]+)/
         case $1
@@ -104,7 +104,7 @@ Ohai.plugin(:Network) do
     end
 
     iface = Mash.new
-    so = shell_out("#{which("ifconfig")} -a")
+    so = shell_out("#{which("ifconfig") || "ifconfig"} -a")
     cint = nil
     so.stdout.lines do |line|
       if line =~ /^([0-9a-zA-Z\.\:\-]+): \S+ mtu (\d+)$/
@@ -159,7 +159,7 @@ Ohai.plugin(:Network) do
       end
     end
 
-    so = shell_out("#{which("arp")} -an")
+    so = shell_out("#{which("arp") || "arp"} -an")
     so.stdout.lines do |line|
       if line =~ /^\S+ \((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) at ([a-fA-F0-9\:]+) on ([a-zA-Z0-9\.\:\-]+).*\[(\w+)\]/
         # MAC addr really should be normalized to include all the zeroes.
@@ -170,7 +170,7 @@ Ohai.plugin(:Network) do
     end
 
     settings = Mash.new
-    so = shell_out("#{which("sysctl")} net")
+    so = shell_out("#{which("sysctl") || "sysctl"} net")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\_]+)\: (.*)/
         # should normalize names between platforms for the same settings.
@@ -182,7 +182,7 @@ Ohai.plugin(:Network) do
     network[:interfaces] = iface
 
     net_counters = Mash.new
-    so = shell_out("#{which("netstat")} -i -d -l -b -n")
+    so = shell_out("#{which("netstat") || "netstat"} -i -d -l -b -n")
     so.stdout.lines do |line|
       if line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>\s+([a-f0-9\:]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/ ||
           line =~ /^([a-zA-Z0-9\.\:\-\*]+)\s+\d+\s+\<[a-zA-Z0-9\#]+\>(\s+)(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)/

--- a/lib/ohai/plugins/darwin/virtualization.rb
+++ b/lib/ohai/plugins/darwin/virtualization.rb
@@ -35,7 +35,7 @@ Ohai.plugin(:Virtualization) do
   end
 
   def fusion_exists?
-    ::File.exist?("/Applications/VMware\ Fusion.app/")
+    file_exist?("/Applications/VMware\ Fusion.app/")
   end
 
   def docker_exists?

--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -45,7 +45,7 @@ Ohai.plugin(:DMI) do
     field = nil
 
     begin
-      so = shell_out("dmidecode")
+      so = shell_out(which("dmidecode"))
       # ==== EXAMPLE RECORD: ====
       # Handle 0x0000, DMI type 0, 24 bytes
       # BIOS Information

--- a/lib/ohai/plugins/dmi.rb
+++ b/lib/ohai/plugins/dmi.rb
@@ -45,7 +45,7 @@ Ohai.plugin(:DMI) do
     field = nil
 
     begin
-      so = shell_out(which("dmidecode"))
+      so = shell_out(which("dmidecode") || "dmidecode")
       # ==== EXAMPLE RECORD: ====
       # Handle 0x0000, DMI type 0, 24 bytes
       # BIOS Information

--- a/lib/ohai/plugins/docker.rb
+++ b/lib/ohai/plugins/docker.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:Docker) do
 
   def docker_info_json
     so = shell_out("docker info --format '{{json .}}'")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       return JSON.parse(so.stdout)
     end
   rescue Ohai::Exceptions::Exec

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -98,8 +98,8 @@ Ohai.plugin(:EC2) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/ec2.rb
+++ b/lib/ohai/plugins/ec2.rb
@@ -31,7 +31,7 @@ Ohai.plugin(:EC2) do
   require "base64"
 
   include Ohai::Mixin::Ec2Metadata
-  include Ohai::Mixin::HttpHelper
+  # include Ohai::Mixin::HttpHelper
 
   provides "ec2"
 
@@ -110,7 +110,7 @@ Ohai.plugin(:EC2) do
 
     # Even if it looks like EC2 try to connect first
     if has_ec2_xen_uuid? || has_ec2_amazon_dmi? || has_ec2_xen_dmi? || has_ec2_identifying_number?
-      return true if can_socket_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR, 80)
+      can_connect?(Ohai::Mixin::Ec2Metadata::EC2_METADATA_ADDR)
     end
   end
 

--- a/lib/ohai/plugins/elixir.rb
+++ b/lib/ohai/plugins/elixir.rb
@@ -24,7 +24,7 @@ Ohai.plugin(:Elixir) do
     # Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
     #
     # Elixir 1.2.4
-    if so.exitstatus == 0 && so.stdout =~ /^Elixir (\S*)/
+    if so.exit_status == 0 && so.stdout =~ /^Elixir (\S*)/
       elixir = Mash.new
       elixir[:version] = $1
       languages[:elixir] = elixir

--- a/lib/ohai/plugins/erlang.rb
+++ b/lib/ohai/plugins/erlang.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Erlang) do
       so = shell_out("erl -eval '{ok, Ver} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), Vsn = binary:bin_to_list(Ver, {0, byte_size(Ver) - 1}), io:format(\"~s,~s,~s\", [Vsn, erlang:system_info(version), erlang:system_info(nif_version)]), halt().' -noshell")
       # Sample output:
       # 19.1,8.1,2.11
-      if so.exitstatus == 0
+      if so.exit_status == 0
         output = so.stdout.split(",")
         erlang[:version] = output[0]
         erlang[:erts_version] = output[1]
@@ -41,7 +41,7 @@ Ohai.plugin(:Erlang) do
       so = shell_out("erl +V")
       # Sample output:
       # Erlang (SMP,ASYNC_THREADS,HIPE) (BEAM) emulator version 7.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         output = so.stderr.split
         if output.length >= 6
           options = output[1]

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:Filesystem) do
   def find_device(name)
     %w{/dev /dev/mapper}.each do |dir|
       path = File.join(dir, name)
-      return path if File.exist?(path)
+      return path if file_exist?(path)
     end
     name
   end
@@ -244,7 +244,7 @@ Ohai.plugin(:Filesystem) do
     end
 
     # Grab any missing mount information from /proc/mounts
-    if File.exist?("/proc/mounts")
+    if file_exist?("/proc/mounts")
       mounts = ""
       # Due to https://tickets.opscode.com/browse/OHAI-196
       # we have to non-block read dev files. Ew.

--- a/lib/ohai/plugins/filesystem.rb
+++ b/lib/ohai/plugins/filesystem.rb
@@ -248,7 +248,7 @@ Ohai.plugin(:Filesystem) do
       mounts = ""
       # Due to https://tickets.opscode.com/browse/OHAI-196
       # we have to non-block read dev files. Ew.
-      f = File.open("/proc/mounts")
+      f = file_open("/proc/mounts")
       loop do
 
         data = f.read_nonblock(4096)

--- a/lib/ohai/plugins/gce.rb
+++ b/lib/ohai/plugins/gce.rb
@@ -40,8 +40,8 @@ Ohai.plugin(:GCE) do
   # @param path[String] abs path to the file
   # @return [String] contents of the file if it exists
   def file_val_if_exists(path)
-    if ::File.exist?(path)
-      ::File.read(path)
+    if file_exist?(path)
+      file_read(path)
     end
   end
 

--- a/lib/ohai/plugins/go.rb
+++ b/lib/ohai/plugins/go.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Go) do
     so = shell_out("go version")
     # Sample output:
     # go version go1.6.1 darwin/amd64
-    if so.exitstatus == 0 && so.stdout =~ /go(\S+)/
+    if so.exit_status == 0 && so.stdout =~ /go(\S+)/
       go = Mash.new
       go[:version] = $1
       languages[:go] = go

--- a/lib/ohai/plugins/groovy.rb
+++ b/lib/ohai/plugins/groovy.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Groovy) do
     so = shell_out("groovy -v")
     # Sample output:
     # Groovy Version: 2.4.6 JVM: 1.8.0_60 Vendor: Oracle Corporation OS: Mac OS X
-    if so.exitstatus == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
+    if so.exit_status == 0 && so.stdout =~ /Groovy Version: (\S+).*JVM: (\S+)/
       groovy = Mash.new
       groovy[:version] = $1
       groovy[:jvm] = $2

--- a/lib/ohai/plugins/haskell.rb
+++ b/lib/ohai/plugins/haskell.rb
@@ -33,7 +33,7 @@ Ohai.plugin(:Haskell) do
 
       # Sample output:
       # The Glorious Glasgow Haskell Compilation System, version 7.6.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:ghc] = Mash.new
         haskell[:ghc][:version] = so.stdout.split[-1]
         haskell[:ghc][:description] = so.stdout.chomp
@@ -48,7 +48,7 @@ Ohai.plugin(:Haskell) do
 
       # Sample output:
       # The Glorious Glasgow Haskell Compilation System, version 7.6.3
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:ghci] = Mash.new
         haskell[:ghci][:version] = so.stdout.split[-1]
         haskell[:ghci][:description] = so.stdout.chomp
@@ -64,7 +64,7 @@ Ohai.plugin(:Haskell) do
       # Sample output:
       # cabal-install version 1.16.0.2
       # using version 1.16.0 of the Cabal library
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:cabal] = Mash.new
         haskell[:cabal][:version] = so.stdout.split("\n")[0].split[-1]
         haskell[:cabal][:description] = so.stdout.split("\n")[0].chomp
@@ -81,7 +81,7 @@ Ohai.plugin(:Haskell) do
       # Version 1.1.0, Git revision 0e9430aad55841b5ff2c6c2851f0548c16bce7cf (3540 commits) x86_64 hpack-0.13.0
       # or
       # Version 1.2.0 x86_64 hpack-0.14.0
-      if so.exitstatus == 0
+      if so.exit_status == 0
         haskell[:stack] = Mash.new
         haskell[:stack][:version] = /Version ([^\s,]*)/.match(so.stdout)[1] rescue nil
         haskell[:stack][:description] = so.stdout.chomp

--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -20,6 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    init_package File.exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
+    init_package file_exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
   end
 end

--- a/lib/ohai/plugins/init_package.rb
+++ b/lib/ohai/plugins/init_package.rb
@@ -20,6 +20,6 @@ Ohai.plugin(:InitPackage) do
   provides "init_package"
 
   collect_data(:linux) do
-    init_package file_exist?("/proc/1/comm") ? File.open("/proc/1/comm").gets.chomp : "init"
+    init_package file_exist?("/proc/1/comm") ? file_open("/proc/1/comm").gets.chomp : "init"
   end
 end

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Java) do
     # java version "1.8.0_60"
     # Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
     # Java HotSpot(TM) 64-Bit Server VM (build 25.60-b23, mixed mode)
-    if so.exitstatus == 0
+    if so.exit_status == 0
       java = Mash.new
       so.stderr.split(/\r?\n/).each do |line|
         case line

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,7 +21,7 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   def get_java_info
-    so = shell_out("java -mx64m -version")
+    so = shell_out("#{which("java")} -mx64m -version")
     # Sample output:
     # java version "1.8.0_60"
     # Java(TM) SE Runtime Environment (build 1.8.0_60-b27)
@@ -63,11 +63,11 @@ Ohai.plugin(:Java) do
   # workaround for this particular annoyance.
   def has_real_java?
     return true unless on_darwin?
-    shell_out("/usr/libexec/java_home").status.success?
+    shell_out("/usr/libexec/java_home").exit_status == 0
   end
 
   def on_darwin?
-    RUBY_PLATFORM.downcase.include?("darwin")
+    collect_os == "darwin"
   end
 
   collect_data do

--- a/lib/ohai/plugins/java.rb
+++ b/lib/ohai/plugins/java.rb
@@ -21,7 +21,7 @@ Ohai.plugin(:Java) do
   depends "languages"
 
   def get_java_info
-    so = shell_out("#{which("java")} -mx64m -version")
+    so = shell_out("#{which("java") || "java"} -mx64m -version")
     # Sample output:
     # java version "1.8.0_60"
     # Java(TM) SE Runtime Environment (build 1.8.0_60-b27)

--- a/lib/ohai/plugins/joyent.rb
+++ b/lib/ohai/plugins/joyent.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Joyent) do
   depends "os", "platform", "virtualization"
 
   def collect_product_file
-    data = ::File.read("/etc/product") rescue nil
+    data = file_read("/etc/product") rescue nil
     if data
       data.strip.split("\n")
     else
@@ -34,7 +34,7 @@ Ohai.plugin(:Joyent) do
   end
 
   def collect_pkgsrc
-    data = ::File.read("/opt/local/etc/pkg_install.conf") rescue nil
+    data = file_read("/opt/local/etc/pkg_install.conf") rescue nil
     if data
       /PKG_PATH=(.*)/.match(data)[1] rescue nil
     end

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -198,7 +198,7 @@ Ohai.plugin(:Kernel) do
     so = shell_out("env lsmod")
     
     if so.stdout == ""
-      so = shell_out(which("lsmod"))
+      so = shell_out(which("lsmod") || "lsmod")
     end
     
     so.stdout.lines do |line|

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -196,6 +196,11 @@ Ohai.plugin(:Kernel) do
 
     modules = Mash.new
     so = shell_out("env lsmod")
+    # NOTE: I don't know that this is right alternative on every linux platform.
+    if so.stdout == ""
+      so = shell_out("/sbin/lsmod")
+    end
+    
     so.stdout.lines do |line|
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { size: $2, refcount: $3 }

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -200,8 +200,8 @@ Ohai.plugin(:Kernel) do
       if line =~ /([a-zA-Z0-9\_]+)\s+(\d+)\s+(\d+)/
         modules[$1] = { size: $2, refcount: $3 }
         # Making sure to get the module version that has been loaded
-        if File.exist?("/sys/module/#{$1}/version")
-          version = File.read("/sys/module/#{$1}/version").chomp.strip
+        if file_exist?("/sys/module/#{$1}/version")
+          version = file_read("/sys/module/#{$1}/version").chomp.strip
           modules[$1]["version"] = version unless version.empty?
         end
       end
@@ -226,7 +226,7 @@ Ohai.plugin(:Kernel) do
     so = shell_out("uname -s")
     kernel[:os] = so.stdout.split($/)[0]
 
-    so = File.open("/etc/release") { |file| file.gets }
+    so = file_open("/etc/release") { |file| file.gets }
     md = /(?<update>\d.*\d)/.match(so)
     kernel[:update] = md[:update] if md
 

--- a/lib/ohai/plugins/kernel.rb
+++ b/lib/ohai/plugins/kernel.rb
@@ -196,9 +196,9 @@ Ohai.plugin(:Kernel) do
 
     modules = Mash.new
     so = shell_out("env lsmod")
-    # NOTE: I don't know that this is right alternative on every linux platform.
+    
     if so.stdout == ""
-      so = shell_out("/sbin/lsmod")
+      so = shell_out(which("lsmod"))
     end
     
     so.stdout.lines do |line|

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -20,23 +20,23 @@ Ohai.plugin(:BlockDevice) do
   provides "block_device"
 
   collect_data(:linux) do
-    if File.exist?("/sys/block")
+    if file_exist?("/sys/block")
       block = Mash.new
-      Dir["/sys/block/*"].each do |block_device_dir|
+      files_in_dir["/sys/block/*"].each do |block_device_dir|
         dir = File.basename(block_device_dir)
         block[dir] = Mash.new
         %w{size removable}.each do |check|
-          if File.exist?("/sys/block/#{dir}/#{check}")
+          if file_exist?("/sys/block/#{dir}/#{check}")
             File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{model rev state timeout vendor queue_depth}.each do |check|
-          if File.exist?("/sys/block/#{dir}/device/#{check}")
+          if file_exist?("/sys/block/#{dir}/device/#{check}")
             File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{rotational physical_block_size logical_block_size}.each do |check|
-          if File.exist?("/sys/block/#{dir}/queue/#{check}")
+          if file_exist?("/sys/block/#{dir}/queue/#{check}")
             File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:BlockDevice) do
   collect_data(:linux) do
     if file_exist?("/sys/block")
       block = Mash.new
-      files_in_dir["/sys/block/*"].each do |block_device_dir|
+      files_in_dir("/sys/block/*").each do |block_device_dir|
         dir = File.basename(block_device_dir)
         block[dir] = Mash.new
         %w{size removable}.each do |check|

--- a/lib/ohai/plugins/linux/block_device.rb
+++ b/lib/ohai/plugins/linux/block_device.rb
@@ -27,17 +27,17 @@ Ohai.plugin(:BlockDevice) do
         block[dir] = Mash.new
         %w{size removable}.each do |check|
           if file_exist?("/sys/block/#{dir}/#{check}")
-            File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{model rev state timeout vendor queue_depth}.each do |check|
           if file_exist?("/sys/block/#{dir}/device/#{check}")
-            File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
         %w{rotational physical_block_size logical_block_size}.each do |check|
           if file_exist?("/sys/block/#{dir}/queue/#{check}")
-            File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+            file_open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
           end
         end
       end

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:LSB) do
   collect_data(:linux) do
     lsb Mash.new
 
-    if File.exist?("/usr/bin/lsb_release")
+    if file_exist?("/usr/bin/lsb_release")
       # From package redhat-lsb on Fedora/Redhat, lsb-release on Debian/Ubuntu
       so = shell_out("lsb_release -a")
       so.stdout.lines do |line|
@@ -39,7 +39,7 @@ Ohai.plugin(:LSB) do
           lsb[:id] = line
         end
       end
-    elsif File.exist?("/etc/lsb-release")
+    elsif file_exist?("/etc/lsb-release")
       # Old, non-standard Debian support
       File.open("/etc/lsb-release").each do |line|
         case line

--- a/lib/ohai/plugins/linux/lsb.rb
+++ b/lib/ohai/plugins/linux/lsb.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:LSB) do
       end
     elsif file_exist?("/etc/lsb-release")
       # Old, non-standard Debian support
-      File.open("/etc/lsb-release").each do |line|
+      file_open("/etc/lsb-release").each do |line|
         case line
         when /^DISTRIB_ID=["']?(.+?)["']?$/
           lsb[:id] = $1

--- a/lib/ohai/plugins/linux/machineid.rb
+++ b/lib/ohai/plugins/linux/machineid.rb
@@ -22,10 +22,10 @@ Ohai.plugin(:Machineid) do
   collect_data(:linux) do
     mid = nil
 
-    if ::File.exist?("/etc/machine-id")
-      mid = ::File.read("/etc/machine-id").chomp
-    elsif ::File.exist?("/var/lib/dbus/machine-id")
-      mid = ::File.read("/var/lib/dbus/machine-id").chomp
+    if file_exist?("/etc/machine-id")
+      mid = file_read("/etc/machine-id").chomp
+    elsif file_exist?("/var/lib/dbus/machine-id")
+      mid = file_read("/var/lib/dbus/machine-id").chomp
     end
 
     if mid

--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:Mdadm) do
 
   collect_data(:linux) do
     # gather a list of all raid arrays
-    if File.exist?("/proc/mdstat")
+    if file_exist?("/proc/mdstat")
       devices = {}
       File.open("/proc/mdstat").each do |line|
         if line =~ /(md[0-9]+)/

--- a/lib/ohai/plugins/linux/mdadm.rb
+++ b/lib/ohai/plugins/linux/mdadm.rb
@@ -55,7 +55,7 @@ Ohai.plugin(:Mdadm) do
     # gather a list of all raid arrays
     if file_exist?("/proc/mdstat")
       devices = {}
-      File.open("/proc/mdstat").each do |line|
+      file_open("/proc/mdstat").each do |line|
         if line =~ /(md[0-9]+)/
           device = Regexp.last_match[1]
           pieces = line.split(/\s+/)

--- a/lib/ohai/plugins/linux/memory.rb
+++ b/lib/ohai/plugins/linux/memory.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Memory) do
     memory[:hugepages] = Mash.new
     memory[:directmap] = Mash.new
 
-    File.open("/proc/meminfo").each do |line|
+    file_open("/proc/meminfo").each do |line|
       case line
       when /^MemTotal:\s+(\d+) (.+)$/
         memory[:total] = "#{$1}#{$2}"

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Network) do
   end
 
   def ipv6_enabled?
-    File.exist? "/proc/net/if_inet6"
+    file_exist? "/proc/net/if_inet6"
   end
 
   def ethtool_binary_path

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -50,7 +50,7 @@ Ohai.plugin(:Network) do
   end
 
   def extract_neighbors(family, iface, neigh_attr)
-    so = shell_out("#{which("ip")} -f #{family[:name]} neigh show")
+    so = shell_out("#{which("ip") || "ip"} -f #{family[:name]} neigh show")
     so.stdout.lines do |line|
       if line =~ /^([a-f0-9\:\.]+)\s+dev\s+([^\s]+)\s+lladdr\s+([a-fA-F0-9\:]+)/
         interface = iface[$2]
@@ -73,7 +73,7 @@ Ohai.plugin(:Network) do
   # 3) and since we're at it, let's populate some :routes attributes
   # (going to do that for both inet and inet6 addresses)
   def check_routing_table(family, iface, default_route_table)
-    so = shell_out("#{which("ip")} -o -f #{family[:name]} route show table #{default_route_table}")
+    so = shell_out("#{which("ip") || "ip"} -o -f #{family[:name]} route show table #{default_route_table}")
     so.stdout.lines do |line|
       line.strip!
       logger.trace("Plugin Network: Parsing #{line}")
@@ -202,7 +202,7 @@ Ohai.plugin(:Network) do
 
   # determine link stats, vlans, queue length, and state for an interface using ip
   def link_statistics(iface, net_counters)
-    so = shell_out("#{which("ip")} -d -s link")
+    so = shell_out("#{which("ip") || "ip"} -d -s link")
     tmp_int = nil
     on_rx = true
     so.stdout.lines do |line|
@@ -305,7 +305,7 @@ Ohai.plugin(:Network) do
   end
 
   def parse_ip_addr(iface)
-    so = shell_out("#{which("ip")} addr")
+    so = shell_out("#{which("ip") || "ip"} addr")
     cint = nil
     so.stdout.lines do |line|
       cint = match_iproute(iface, line, cint)

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -42,11 +42,11 @@ Ohai.plugin(:Network) do
   end
 
   def is_openvz?
-    @openvz ||= ::File.directory?("/proc/vz")
+    @openvz ||= file_exist?("/proc/vz")
   end
 
   def is_openvz_host?
-    is_openvz? && ::File.directory?("/proc/bc")
+    is_openvz? && file_exist?("/proc/bc")
   end
 
   def extract_neighbors(family, iface, neigh_attr)

--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -50,7 +50,7 @@ Ohai.plugin(:Network) do
   end
 
   def extract_neighbors(family, iface, neigh_attr)
-    so = shell_out("ip -f #{family[:name]} neigh show")
+    so = shell_out("#{which("ip")} -f #{family[:name]} neigh show")
     so.stdout.lines do |line|
       if line =~ /^([a-f0-9\:\.]+)\s+dev\s+([^\s]+)\s+lladdr\s+([a-fA-F0-9\:]+)/
         interface = iface[$2]
@@ -73,7 +73,7 @@ Ohai.plugin(:Network) do
   # 3) and since we're at it, let's populate some :routes attributes
   # (going to do that for both inet and inet6 addresses)
   def check_routing_table(family, iface, default_route_table)
-    so = shell_out("ip -o -f #{family[:name]} route show table #{default_route_table}")
+    so = shell_out("#{which("ip")} -o -f #{family[:name]} route show table #{default_route_table}")
     so.stdout.lines do |line|
       line.strip!
       logger.trace("Plugin Network: Parsing #{line}")
@@ -202,7 +202,7 @@ Ohai.plugin(:Network) do
 
   # determine link stats, vlans, queue length, and state for an interface using ip
   def link_statistics(iface, net_counters)
-    so = shell_out("ip -d -s link")
+    so = shell_out("#{which("ip")} -d -s link")
     tmp_int = nil
     on_rx = true
     so.stdout.lines do |line|
@@ -305,7 +305,7 @@ Ohai.plugin(:Network) do
   end
 
   def parse_ip_addr(iface)
-    so = shell_out("ip addr")
+    so = shell_out("#{which("ip")} addr")
     cint = nil
     so.stdout.lines do |line|
       cint = match_iproute(iface, line, cint)

--- a/lib/ohai/plugins/linux/systemd_paths.rb
+++ b/lib/ohai/plugins/linux/systemd_paths.rb
@@ -19,9 +19,6 @@
 Ohai.plugin(:SystemdPaths) do
   provides "systemd_paths"
 
-  require "ohai/util/file_helper"
-  include Ohai::Util::FileHelper
-
   collect_data(:linux) do
     systemd_path_path = which("systemd-path")
     if systemd_path_path

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -22,16 +22,21 @@ Ohai.plugin(:Virtualization) do
   require "ohai/mixin/dmi_decode"
   include Ohai::Mixin::DmiDecode
 
+  # TODO: A series of expensive operations are about to begin
+  #   This which operation will look through all the possible paths
+  #   and when it is done it returns the same name back if it can't find it
+  #   
+    
   def lxc_version_exists?
-    which("lxc-version") || which("lxc-start")
+    which("lxc-version") != "lxc-version" || which("lxc-start") != "lxc-start"
   end
 
   def nova_exists?
-    which("nova")
+    which("nova") != "nova"
   end
 
   def docker_exists?
-    which("docker")
+    which("docker") != "docker"
   end
 
   collect_data(:linux) do

--- a/lib/ohai/plugins/linux/virtualization.rb
+++ b/lib/ohai/plugins/linux/virtualization.rb
@@ -28,15 +28,15 @@ Ohai.plugin(:Virtualization) do
   #   
     
   def lxc_version_exists?
-    which("lxc-version") != "lxc-version" || which("lxc-start") != "lxc-start"
+    which("lxc-version") || which("lxc-start")
   end
 
   def nova_exists?
-    which("nova") != "nova"
+    which("nova")
   end
 
   def docker_exists?
-    which("docker") != "docker"
+    which("docker")
   end
 
   collect_data(:linux) do

--- a/lib/ohai/plugins/lua.rb
+++ b/lib/ohai/plugins/lua.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Lua) do
     so = shell_out("lua -v")
     # Sample output:
     # Lua 5.2.4  Copyright (C) 1994-2015 Lua.org, PUC-Rio
-    if so.exitstatus == 0
+    if so.exit_status == 0
       lua = Mash.new
       # at some point in lua's history they went from outputting the version
       # on stderr to doing it on stdout. This handles old / new versions

--- a/lib/ohai/plugins/mono.rb
+++ b/lib/ohai/plugins/mono.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Mono) do
     # 	Misc:          softtrace
     # 	LLVM:          supported, not enabled.
     # 	GC:            sgen
-    if so.exitstatus == 0
+    if so.exit_status == 0
       mono = Mash.new
       output = so.stdout.split
       mono[:version] = output[4] unless output[4].nil?

--- a/lib/ohai/plugins/nodejs.rb
+++ b/lib/ohai/plugins/nodejs.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Nodejs) do
     so = shell_out("node -v")
     # Sample output:
     # v5.10.1
-    if so.exitstatus == 0
+    if so.exit_status == 0
       nodejs = Mash.new
       output = so.stdout.split
       if output.length >= 1

--- a/lib/ohai/plugins/ohai.rb
+++ b/lib/ohai/plugins/ohai.rb
@@ -24,5 +24,32 @@ Ohai.plugin(:Ohai) do
     chef_packages[:ohai] = Mash.new
     chef_packages[:ohai][:version] = Ohai::VERSION
     chef_packages[:ohai][:ohai_root] = Ohai::OHAI_ROOT
+
+        # welcome to a quick implementation that gets the job done.
+
+    # Try and find chef. If it results in returning us chef its not on the path
+    # So we want to look for it in the usual install locations.
+    ohai_bin = which('ohai') 
+    if ohai_bin == 'ohai'
+      if file_exist?('/opt/chef/bin/ohai')
+        ohai_bin = '/opt/chef/bin/ohai'
+      elsif file_exist?('/opt/chefdk/bin/ohai')
+        ohai_bin = '/opt/chefdk/bin/ohai'
+      end
+    end
+
+    if ohai_bin != 'ohai'
+      ohai_app_name, version = shell_out("#{ohai_bin} --version").stdout.chomp.split(' ')
+
+      chef_packages Mash.new unless chef_packages
+      chef_packages[:ohai] = Mash.new
+      chef_packages[:ohai][:version] = version
+
+      # There is an assumption that it exists somewhere within this directory.
+      # There could multiple and I'm not sure which one would be prefered. I honestly would
+      # just put them all into the value here in an array.
+      ohai_root = shell_out("find /opt -path '*/ohai-#{version}/lib'").stdout.chomp.lines.first
+      chef_packages[:ohai][:ohai_root] = ohai_root
+    end
   end
 end

--- a/lib/ohai/plugins/ohai.rb
+++ b/lib/ohai/plugins/ohai.rb
@@ -25,7 +25,8 @@ Ohai.plugin(:Ohai) do
     # Try and find chef. If it results in returning us chef its not on the path
     # So we want to look for it in the usual install locations.
     ohai_bin = which('ohai') 
-    if ohai_bin == 'ohai'
+    
+    if ohai_bin.nil?
       if file_exist?('/opt/chef/bin/ohai')
         ohai_bin = '/opt/chef/bin/ohai'
       elsif file_exist?('/opt/chefdk/bin/ohai')
@@ -33,7 +34,7 @@ Ohai.plugin(:Ohai) do
       end
     end
 
-    if ohai_bin != 'ohai'
+    if ohai_bin
       ohai_app_name, version = shell_out("#{ohai_bin} --version").stdout.chomp.split(' ')
 
       chef_packages Mash.new unless chef_packages

--- a/lib/ohai/plugins/ohai.rb
+++ b/lib/ohai/plugins/ohai.rb
@@ -20,12 +20,7 @@ Ohai.plugin(:Ohai) do
   provides "chef_packages/ohai"
 
   collect_data do
-    chef_packages Mash.new unless chef_packages
-    chef_packages[:ohai] = Mash.new
-    chef_packages[:ohai][:version] = Ohai::VERSION
-    chef_packages[:ohai][:ohai_root] = Ohai::OHAI_ROOT
-
-        # welcome to a quick implementation that gets the job done.
+    # welcome to a quick implementation that gets the job done.
 
     # Try and find chef. If it results in returning us chef its not on the path
     # So we want to look for it in the usual install locations.

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -1,13 +1,7 @@
 
 Ohai.plugin(:Passwd) do
-  require "etc"
   provides "etc", "current_user"
   optional true
-
-  def fix_encoding(str)
-    str.force_encoding(Encoding.default_external) if str.respond_to?(:force_encoding)
-    str
-  end
 
   collect_data do
     unless etc
@@ -16,23 +10,20 @@ Ohai.plugin(:Passwd) do
       etc[:passwd] = Mash.new
       etc[:group] = Mash.new
 
-      Etc.passwd do |entry|
-        user_passwd_entry = Mash.new(dir: entry.dir, gid: entry.gid, uid: entry.uid, shell: entry.shell, gecos: entry.gecos)
-        user_passwd_entry.each_value { |v| fix_encoding(v) }
-        entry_name = fix_encoding(entry.name)
-        etc[:passwd][entry_name] = user_passwd_entry unless etc[:passwd].key?(entry_name)
+      file_read('/etc/passwd').lines.each do |line|
+        name, has_password, uid, gid, gecos, dir, shell = line.strip.split(':')
+        user_passwd_entry = Mash.new(dir: dir, gid: gid, uid: uid, shell: shell, gecos: gecos)
+        etc[:passwd][name] = user_passwd_entry unless etc[:passwd].key?(name)
       end
 
-      Etc.group do |entry|
-        group_entry = Mash.new(gid: entry.gid,
-                               members: entry.mem.map { |u| fix_encoding(u) })
-
-        etc[:group][fix_encoding(entry.name)] = group_entry
+      file_read('/etc/group').lines.each do |line|
+        name, has_password, gid, members = line.strip.split(':')
+        etc[:group][name] = Mash.new(gid: gid, members: members.to_s.split(","))
       end
     end
 
     unless current_user
-      current_user fix_encoding(Etc.getpwuid(Process.euid).name)
+      current_user shell_out('whoami').stdout.chomp
     end
   end
 

--- a/lib/ohai/plugins/passwd.rb
+++ b/lib/ohai/plugins/passwd.rb
@@ -12,13 +12,13 @@ Ohai.plugin(:Passwd) do
 
       file_read('/etc/passwd').lines.each do |line|
         name, has_password, uid, gid, gecos, dir, shell = line.strip.split(':')
-        user_passwd_entry = Mash.new(dir: dir, gid: gid, uid: uid, shell: shell, gecos: gecos)
+        user_passwd_entry = Mash.new(dir: dir, gid: gid.to_i, uid: uid.to_i, shell: shell, gecos: gecos)
         etc[:passwd][name] = user_passwd_entry unless etc[:passwd].key?(name)
       end
 
       file_read('/etc/group').lines.each do |line|
         name, has_password, gid, members = line.strip.split(':')
-        etc[:group][name] = Mash.new(gid: gid, members: members.to_s.split(","))
+        etc[:group][name] = Mash.new(gid: gid.to_i, members: members.to_s.split(","))
       end
     end
 

--- a/lib/ohai/plugins/perl.rb
+++ b/lib/ohai/plugins/perl.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Perl) do
     # Sample output:
     # version='5.18.2';
     # archname='darwin-thread-multi-2level';
-    if so.exitstatus == 0
+    if so.exit_status == 0
       perl = Mash.new
       so.stdout.split(/\r?\n/).each do |line|
         case line

--- a/lib/ohai/plugins/php.rb
+++ b/lib/ohai/plugins/php.rb
@@ -29,7 +29,7 @@ Ohai.plugin(:PHP) do
     # PHP 5.5.31 (cli) (built: Feb 20 2016 20:33:10)
     # Copyright (c) 1997-2015 The PHP Group
     # Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies
-    if so.exitstatus == 0
+    if so.exit_status == 0
       php = Mash.new
       so.stdout.each_line do |line|
         case line

--- a/lib/ohai/plugins/powershell.rb
+++ b/lib/ohai/plugins/powershell.rb
@@ -34,7 +34,7 @@ Ohai.plugin(:Powershell) do
     # PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0}
     # PSRemotingProtocolVersion      2.2
 
-    if so.exitstatus == 0
+    if so.exit_status == 0
       powershell = Mash.new
       version_info = {}
       so.stdout.strip.each_line do |line|

--- a/lib/ohai/plugins/python.rb
+++ b/lib/ohai/plugins/python.rb
@@ -27,7 +27,7 @@ Ohai.plugin(:Python) do
     # Sample output:
     # 2.7.11 (default, Dec 26 2015, 17:47:53)
     # [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
-    if so.exitstatus == 0
+    if so.exit_status == 0
       python = Mash.new
       output = so.stdout.split
       python[:version] = output[0]

--- a/lib/ohai/plugins/rackspace.rb
+++ b/lib/ohai/plugins/rackspace.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Rackspace) do
   # false:: Otherwise
   def has_rackspace_metadata?
     so = shell_out("xenstore-read vm-data/provider_data/provider")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.strip.casecmp("rackspace") == 0
     end
   rescue Ohai::Exceptions::Exec
@@ -99,7 +99,7 @@ Ohai.plugin(:Rackspace) do
   #
   def get_region
     so = shell_out("xenstore-ls vm-data/provider_data")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.split("\n").each do |line|
         rackspace[:region] = line.split[2].delete('\"') if line =~ /^region/
       end
@@ -113,7 +113,7 @@ Ohai.plugin(:Rackspace) do
   #
   def get_instance_id
     so = shell_out("xenstore-read name")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       rackspace[:instance_id] = so.stdout.gsub(/instance-/, "")
     end
   rescue Ohai::Exceptions::Exec
@@ -125,11 +125,11 @@ Ohai.plugin(:Rackspace) do
   #
   def get_private_networks
     so = shell_out("xenstore-ls vm-data/networking")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       networks = []
       so.stdout.split("\n").map { |l| l.split("=").first.strip }.map do |item|
         so = shell_out("xenstore-read vm-data/networking/#{item}")
-        if so.exitstatus == 0
+        if so.exit_status == 0
           networks.push(FFI_Yajl::Parser.new.parse(so.stdout))
         else
           logger.trace("Plugin Rackspace: Unable to capture custom private networking information for Rackspace cloud")

--- a/lib/ohai/plugins/ruby.rb
+++ b/lib/ohai/plugins/ruby.rb
@@ -67,7 +67,7 @@ Ohai.plugin(:Ruby) do
                     run_ruby("require 'rubygems'; puts ::Gem.default_exec_format % 'gem'"),
                     "gem",
                    ].map { |bin| ::File.join(bin_dir, bin) }
-    gem_binary = gem_binaries.find { |bin| ::File.exist? bin }
+    gem_binary = gem_binaries.find { |bin| file_exist? bin }
     if gem_binary
       languages[:ruby][:gems_dir] = run_ruby "puts %x{#{ruby_bin} #{gem_binary} env gemdir}.chomp!"
       languages[:ruby][:gem_bin] = gem_binary

--- a/lib/ohai/plugins/rust.rb
+++ b/lib/ohai/plugins/rust.rb
@@ -22,7 +22,7 @@ Ohai.plugin(:Rust) do
     so = shell_out("rustc --version")
     # Sample output:
     # rustc 1.7.0
-    if so.exitstatus == 0
+    if so.exit_status == 0
       rust = Mash.new
       rust[:version] = so.stdout.split[1]
       languages[:rust] = rust if rust[:version]

--- a/lib/ohai/plugins/scala.rb
+++ b/lib/ohai/plugins/scala.rb
@@ -25,7 +25,7 @@ Ohai.plugin(:Scala) do
       # Sample output:
       # cat: /release: No such file or directory
       # Scala code runner version 2.12.1 -- Copyright 2002-2016, LAMP/EPFL and Lightbend, Inc.
-      if so.exitstatus == 0
+      if so.exit_status == 0
         scala[:version] = so.stderr.match(/.*version (\S*)/)[1]
       end
     rescue Ohai::Exceptions::Exec

--- a/lib/ohai/plugins/scaleway.rb
+++ b/lib/ohai/plugins/scaleway.rb
@@ -26,7 +26,7 @@ Ohai.plugin(:Scaleway) do
   # looks for `scaleway` keyword in kernel command line
   # @return [Boolean] do we have the keyword or not?
   def has_scaleway_cmdline?
-    if ::File.read("/proc/cmdline") =~ /scaleway/
+    if file_read("/proc/cmdline") =~ /scaleway/
       logger.trace("Plugin Scaleway: has_scaleway_cmdline? == true")
       return true
     end

--- a/lib/ohai/plugins/shells.rb
+++ b/lib/ohai/plugins/shells.rb
@@ -20,9 +20,9 @@ Ohai.plugin(:Shells) do
   provides "shells"
 
   collect_data do
-    if ::File.exist?("/etc/shells")
+    if file_exist?("/etc/shells")
       shells []
-      ::File.readlines("/etc/shells").each do |line|
+      file_readlines("/etc/shells").each do |line|
         # remove carriage returns and skip over comments / empty lines
         shells << line.chomp if line[0] == "/"
       end

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -20,7 +20,7 @@ Ohai.plugin(:Platform) do
   provides "platform", "platform_version", "platform_build", "platform_family"
 
   collect_data(:solaris2) do
-    if File.exist?("/sbin/uname")
+    if file_exist?("/sbin/uname")
       uname_exec = "/sbin/uname"
     else
       uname_exec = "uname"

--- a/lib/ohai/plugins/solaris2/platform.rb
+++ b/lib/ohai/plugins/solaris2/platform.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Platform) do
       end
     end
 
-    File.open("/etc/release") do |file|
+    file_open("/etc/release") do |file|
       while ( line = file.gets )
         case line
         when /^.*(SmartOS).*$/

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -36,7 +36,7 @@ Ohai.plugin(:Virtualization) do
 
     # Detect paravirt KVM/QEMU from cpuinfo, report as KVM
     psrinfo_path = Ohai.abs_path( "/usr/sbin/psrinfo" )
-    if File.exist?(psrinfo_path)
+    if file_exist?(psrinfo_path)
       so = shell_out("#{psrinfo_path} -pv")
       if so.stdout =~ /QEMU Virtual CPU|Common KVM processor|Common 32-bit KVM processor/
         virtualization[:system] = "kvm"

--- a/lib/ohai/plugins/solaris2/virtualization.rb
+++ b/lib/ohai/plugins/solaris2/virtualization.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:Virtualization) do
       virtualization[:systems][guest.to_sym] = "guest"
     end
 
-    if File.executable?("/usr/sbin/zoneadm")
+    if file_executable?("/usr/sbin/zoneadm")
       zones = Mash.new
       so = shell_out("zoneadm list -pc")
       so.stdout.lines do |line|

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -38,9 +38,9 @@ Ohai.plugin(:SSHHostKey) do
   collect_data do
     keys[:ssh] = Mash.new
 
-    sshd_config = if File.exist?("/etc/ssh/sshd_config")
+    sshd_config = if file_exist?("/etc/ssh/sshd_config")
                     "/etc/ssh/sshd_config"
-                  elsif File.exist?("/etc/sshd_config")
+                  elsif file_exist?("/etc/sshd_config")
                     # Darwin
                     "/etc/sshd_config"
                   else
@@ -62,21 +62,21 @@ Ohai.plugin(:SSHHostKey) do
       end
     end
 
-    if keys[:ssh][:host_dsa_public].nil? && File.exist?("/etc/ssh/ssh_host_dsa_key.pub")
+    if keys[:ssh][:host_dsa_public].nil? && file_exist?("/etc/ssh/ssh_host_dsa_key.pub")
       keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_rsa_public].nil? && File.exist?("/etc/ssh/ssh_host_rsa_key.pub")
+    if keys[:ssh][:host_rsa_public].nil? && file_exist?("/etc/ssh/ssh_host_rsa_key.pub")
       keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
     end
 
-    if keys[:ssh][:host_ecdsa_public].nil? && File.exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
+    if keys[:ssh][:host_ecdsa_public].nil? && file_exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
       content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
     end
 
-    if keys[:ssh][:host_ed25519_public].nil? && File.exist?("/etc/ssh/ssh_host_ed25519_key.pub")
+    if keys[:ssh][:host_ed25519_public].nil? && file_exist?("/etc/ssh/ssh_host_ed25519_key.pub")
       keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:SSHHostKey) do
         conf.each_line do |line|
           if line =~ /^hostkey\s/i
             pub_file = "#{line.split[1]}.pub"
-            content = IO.read(pub_file).split
+            content = file_read(pub_file).split
             key_type, key_subtype = extract_keytype?(content)
             keys[:ssh]["host_#{key_type}_public"] = content[1] unless key_type.nil?
             keys[:ssh]["host_#{key_type}_type"] = key_subtype unless key_subtype.nil?
@@ -63,21 +63,21 @@ Ohai.plugin(:SSHHostKey) do
     end
 
     if keys[:ssh][:host_dsa_public].nil? && file_exist?("/etc/ssh/ssh_host_dsa_key.pub")
-      keys[:ssh][:host_dsa_public] = IO.read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
+      keys[:ssh][:host_dsa_public] = file_read("/etc/ssh/ssh_host_dsa_key.pub").split[1]
     end
 
     if keys[:ssh][:host_rsa_public].nil? && file_exist?("/etc/ssh/ssh_host_rsa_key.pub")
-      keys[:ssh][:host_rsa_public] = IO.read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
+      keys[:ssh][:host_rsa_public] = file_read("/etc/ssh/ssh_host_rsa_key.pub").split[1]
     end
 
     if keys[:ssh][:host_ecdsa_public].nil? && file_exist?("/etc/ssh/ssh_host_ecdsa_key.pub")
-      content = IO.read("/etc/ssh/ssh_host_ecdsa_key.pub")
+      content = file_read("/etc/ssh/ssh_host_ecdsa_key.pub")
       keys[:ssh][:host_ecdsa_public] = content.split[1]
       keys[:ssh][:host_ecdsa_type] = content.split[0]
     end
 
     if keys[:ssh][:host_ed25519_public].nil? && file_exist?("/etc/ssh/ssh_host_ed25519_key.pub")
-      keys[:ssh][:host_ed25519_public] = IO.read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
+      keys[:ssh][:host_ed25519_public] = file_read("/etc/ssh/ssh_host_ed25519_key.pub").split[1]
     end
   end
 end

--- a/lib/ohai/plugins/ssh_host_key.rb
+++ b/lib/ohai/plugins/ssh_host_key.rb
@@ -49,7 +49,7 @@ Ohai.plugin(:SSHHostKey) do
                   end
 
     if sshd_config
-      File.open(sshd_config) do |conf|
+      file_open(sshd_config) do |conf|
         conf.each_line do |line|
           if line =~ /^hostkey\s/i
             pub_file = "#{line.split[1]}.pub"

--- a/lib/ohai/plugins/sysconf.rb
+++ b/lib/ohai/plugins/sysconf.rb
@@ -24,7 +24,7 @@ Ohai.plugin(:Sysconf) do
     if getconf_path
       getconf = shell_out("#{getconf_path} -a")
 
-      if getconf.exitstatus == 0
+      if getconf.exit_status == 0
         sysconf Mash.new unless sysconf
 
         getconf.stdout.split("\n").each do |line|

--- a/lib/ohai/plugins/timezone.rb
+++ b/lib/ohai/plugins/timezone.rb
@@ -19,6 +19,12 @@ Ohai.plugin(:Timezone) do
 
   collect_data(:default) do
     time Mash.new unless time
+    logger.warn('Collecting time locally and not remotely')
     time[:timezone] = Time.now.getlocal.zone
+  end
+
+  collect_data(:linux) do
+    time Mash.new unless time
+    time[:timezone] = shell_out('date +%Z').stdout.chomp
   end
 end

--- a/lib/ohai/plugins/uptime.rb
+++ b/lib/ohai/plugins/uptime.rb
@@ -54,7 +54,7 @@ Ohai.plugin(:Uptime) do
   end
 
   collect_data(:linux) do
-    uptime, idletime = File.open("/proc/uptime").gets.split(" ")
+    uptime, idletime = file_open("/proc/uptime").gets.split(" ")
     uptime_seconds uptime.to_i
     uptime seconds_to_human(uptime.to_i)
     idletime_seconds idletime.to_i

--- a/lib/ohai/plugins/virtualbox.rb
+++ b/lib/ohai/plugins/virtualbox.rb
@@ -23,7 +23,7 @@ Ohai.plugin(:Virtualbox) do
 
     so = shell_out("VBoxControl guestproperty enumerate")
 
-    if so.exitstatus == 0
+    if so.exit_status == 0
       virtualbox Mash.new
       virtualbox[:host] = Mash.new
       virtualbox[:guest] = Mash.new

--- a/lib/ohai/plugins/vmware.rb
+++ b/lib/ohai/plugins/vmware.rb
@@ -41,7 +41,7 @@ Ohai.plugin(:VMware) do
   end
 
   def get_vm_attributes(vmtools_path)
-    if !File.exist?(vmtools_path)
+    if !file_exist?(vmtools_path)
       logger.trace("Plugin VMware: #{vmtools_path} not found")
     else
       vmware Mash.new

--- a/lib/ohai/plugins/windows/network.rb
+++ b/lib/ohai/plugins/windows/network.rb
@@ -198,7 +198,7 @@ Ohai.plugin(:Network) do
 
     cint = nil
     so = shell_out("arp -a")
-    if so.exitstatus == 0
+    if so.exit_status == 0
       so.stdout.lines do |line|
         if line =~ /^Interface:\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+[-]+\s+(0x\S+)/
           cint = $2.downcase

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -51,13 +51,13 @@ module Ohai
             raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin version #{plugin.version} for plugin #{plugin}"
           end
         rescue Ohai::Exceptions::Error # rubocop: disable Lint/ShadowedException
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           raise
         rescue SystemExit # abort or exit from plug-in should exit Ohai with failure code
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           raise
         rescue Exception, Errno::ENOENT => e
-          require 'pry' ; binding.pry
+          # require 'pry' ; binding.pry
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -51,10 +51,13 @@ module Ohai
             raise Ohai::Exceptions::InvalidPlugin, "Invalid plugin version #{plugin.version} for plugin #{plugin}"
           end
         rescue Ohai::Exceptions::Error # rubocop: disable Lint/ShadowedException
+          require 'pry' ; binding.pry
           raise
         rescue SystemExit # abort or exit from plug-in should exit Ohai with failure code
+          require 'pry' ; binding.pry
           raise
         rescue Exception, Errno::ENOENT => e
+          require 'pry' ; binding.pry
           logger.trace("Plugin #{plugin.name} threw exception #{e.inspect} #{e.backtrace.join("\n")}")
         end
       end

--- a/lib/ohai/runner.rb
+++ b/lib/ohai/runner.rb
@@ -88,7 +88,10 @@ module Ohai
         end
 
         if dependency_providers.empty?
+          # TODO: assigning the backend to the data of the plugin.
+          #   is probably not the best approach but it was an easy spot to start.
           next_plugin.data[:backend] = backend
+          # require 'pry' ; binding.pry
           @safe_run ? next_plugin.safe_run : next_plugin.run
           next_plugin.data[:backend] = nil
           if next_plugin.failed

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -110,11 +110,21 @@ module Ohai
           Train.create('docker', host: host)
         elsif config[:target].to_s.start_with?('ssh')
           # ssh://user:password@host:port
+          # TODO: This has already been written within inspec. It would be
+          #   best to use that code.
           user_pass, host_port = config[:target].gsub('ssh://','').split('@')
+          user, pass = user_pass.split(':')
           host, port = host_port.split(':')
-          # require 'pry' ; binding.pry
+
+          train_config = {
+            host: host,
+            port: port,
+            user: user,
+            password: password
+            key_files = config[:keyfile]
+          }
           
-          Train.create('ssh',host: host, port: port || 22, user: user_pass, key_files: '~/.ssh/ohai.pem')
+          Train.create('ssh',train_config)
         else
           fail 'unsupported target'
         end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -144,8 +144,13 @@ module Ohai
           
         @provides_map.all_plugins(attribute_filter).each do |plugin|
           # This is a good place to use the train connection to
-          # execute a command or look at a file
+          # execute a command or look at a file.
+          # If you run ohai with a particular plugin in mind it makes 
+          # it easier to troubleshoot:
+          #
+          # plugin.data[:backend] = conn
           # require 'pry' ; binding.pry
+          # plugin.run_plugin
           @runner.run_plugin(plugin, conn)
         end
         conn.close

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -120,10 +120,10 @@ module Ohai
             host: host,
             port: port,
             user: user,
-            password: password
-            key_files = config[:keyfile]
+            password: pass,
+            key_files: config[:keyfiles]
           }
-          
+
           Train.create('ssh',train_config)
         else
           fail 'unsupported target'
@@ -148,6 +148,7 @@ module Ohai
         conn.close
 
       rescue Ohai::Exceptions::AttributeNotFound, Ohai::Exceptions::DependencyCycle => e
+        require 'pry' ; binding.pry
         logger.error("Encountered error while running plugins: #{e.inspect}")
         raise
       end

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -143,6 +143,9 @@ module Ohai
         conn = backend.connection
           
         @provides_map.all_plugins(attribute_filter).each do |plugin|
+          # This is a good place to use the train connection to
+          # execute a command or look at a file
+          # require 'pry' ; binding.pry
           @runner.run_plugin(plugin, conn)
         end
         conn.close

--- a/lib/ohai/system.rb
+++ b/lib/ohai/system.rb
@@ -151,7 +151,7 @@ module Ohai
         conn.close
 
       rescue Ohai::Exceptions::AttributeNotFound, Ohai::Exceptions::DependencyCycle => e
-        require 'pry' ; binding.pry
+        # require 'pry' ; binding.pry
         logger.error("Encountered error while running plugins: #{e.inspect}")
         raise
       end

--- a/ohai.gemspec
+++ b/ohai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "wmi-lite", "~> 1.0"
   s.add_dependency "ffi", "~> 1.9"
   s.add_dependency "chef-config", ">= 12.8", "< 16"
+  s.add_dependency "train", ">= 2.0.2"
   # Note for ohai developers: If chef-config causes you grief, try:
   #     bundle install --with development
   # this should work as long as chef is a development dependency in Gemfile.

--- a/scans/centos-ec2-commands.txt
+++ b/scans/centos-ec2-commands.txt
@@ -1,0 +1,1281 @@
+(uname -s)
+(uname -m)
+(test -f /etc/debian_version && cat /etc/debian_version)
+(test -f /etc/os-release && cat /etc/os-release)
+(test -f /usr/bin/FastCli)
+(show version | json)
+(test -f /etc/lsb-release && cat /etc/lsb-release)
+(test -f /usr/bin/lsb-release && cat /usr/bin/lsb-release)
+(test -f /etc/oracle-release && cat /etc/oracle-release)
+(test -f /etc/enterprise-release && cat /etc/enterprise-release)
+(test -f /etc/parallels-release && cat /etc/parallels-release)
+(test -f /etc/system-release && cat /etc/system-release)
+(test -f /etc/redhat-release && cat /etc/redhat-release)
+(cat /proc/uptime || echo -n)
+(which chef-client)
+(/usr/bin/chef-client --version)
+(find /opt -path '*/chef-14.11.21/lib')
+(which ohai)
+(/usr/bin/ohai --version)
+(find /opt -path '*/ohai-14.8.10/lib')
+(scala -version)
+(groovy -v)
+(rustc --version)
+(php -v)
+(ghc --version)
+(ghci --version)
+(cabal --version)
+(stack --version)
+(python -c "import sys; print (sys.version)")
+(go version)
+(gcc -v)
+(/lib/libc.so.6)
+(/lib64/libc.so.6)
+(cc -V -flags)
+(elixir -v)
+(ruby -e "require 'rbconfig'; puts %Q(platform=#{RUBY_PLATFORM},version=#{RUBY_VERSION},release_date=#{RUBY_RELEASE_DATE},target=#{RbConfig::CONFIG['target']},target_cpu=#{RbConfig::CONFIG['target_cpu']},target_vendor=#{RbConfig::CONFIG['target_vendor']},target_os=#{RbConfig::CONFIG['target_os']},host=#{RbConfig::CONFIG['host']},host_cpu=#{RbConfig::CONFIG['host_cpu']},host_os=#{RbConfig::CONFIG['host_os']},host_vendor=#{RbConfig::CONFIG['host_vendor']},bin_dir=#{RbConfig::CONFIG['bindir']},ruby_bin=#{::File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])},)")
+(ruby -e "require 'rbconfig'; require 'rubygems'; puts ::Gem.default_exec_format % 'gem'")
+(perl -V:version -V:archname)
+(node -v)
+(erl -eval '{ok, Ver} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), Vsn = binary:bin_to_list(Ver, {0, byte_size(Ver) - 1}), io:format("~s,~s,~s", [Vsn, erlang:system_info(version), erlang:system_info(nif_version)]), halt().' -noshell)
+(erl +V)
+(which java)
+(echo $PATH)
+(stat -L /usr/local/bin/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/java 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:01:19-05:00] WARN: Plugin Java: did not find java
+(java -mx64m -version)
+(lua -v)
+(mono -V)
+(which ip)
+(echo $PATH)
+(stat -L /usr/local/bin/ip 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/ip 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/ip 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/ip 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/ip 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(test -e /proc/net/if_inet6)
+(which ip)
+(echo $PATH)
+(/sbin/ip addr)
+(which ip)
+(echo $PATH)
+(/sbin/ip -d -s link)
+(which ip)
+(echo $PATH)
+(/sbin/ip -f inet neigh show)
+(which ip)
+(echo $PATH)
+(/sbin/ip -o -f inet route show table main)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(which ip)
+(echo $PATH)
+(/sbin/ip -f inet6 neigh show)
+(which ip)
+(echo $PATH)
+(/sbin/ip -o -f inet6 route show table main)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(test -e /proc/vz)
+(which ethtool)
+(echo $PATH)
+(stat -L /usr/local/bin/ethtool 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/ethtool 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/ethtool 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/ethtool 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/ethtool 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(/sbin/ethtool eth0)
+(/sbin/ethtool -g eth0)
+(uname -s)
+(uname -r)
+(uname -v)
+(uname -m)
+(uname -p)
+(uname -o)
+(env lsmod)
+(which lsmod)
+(echo $PATH)
+(stat -L /usr/local/bin/lsmod 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/lsmod 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/lsmod 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/lsmod 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/lsmod 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(/sbin/lsmod)
+(test -e /sys/module/ipt_REJECT/version)
+(test -e /sys/module/nf_conntrack_ipv4/version)
+(test -e /sys/module/nf_defrag_ipv4/version)
+(test -e /sys/module/iptable_filter/version)
+(test -e /sys/module/ip_tables/version)
+(test -e /sys/module/ip6t_REJECT/version)
+(test -e /sys/module/nf_conntrack_ipv6/version)
+(test -e /sys/module/nf_defrag_ipv6/version)
+(test -e /sys/module/xt_state/version)
+(test -e /sys/module/nf_conntrack/version)
+(test -e /sys/module/ip6table_filter/version)
+(test -e /sys/module/ip6_tables/version)
+(test -e /sys/module/ib_ipoib/version)
+(cat /sys/module/ib_ipoib/version || echo -n)
+(test -e /sys/module/rdma_ucm/version)
+(test -e /sys/module/ib_ucm/version)
+(test -e /sys/module/ib_uverbs/version)
+(test -e /sys/module/ib_umad/version)
+(test -e /sys/module/rdma_cm/version)
+(test -e /sys/module/ib_cm/version)
+(test -e /sys/module/iw_cm/version)
+(test -e /sys/module/ib_sa/version)
+(test -e /sys/module/ib_mad/version)
+(test -e /sys/module/ib_core/version)
+(test -e /sys/module/ib_addr/version)
+(test -e /sys/module/ipv6/version)
+(test -e /sys/module/xen_netfront/version)
+(test -e /sys/module/i2c_piix4/version)
+(test -e /sys/module/i2c_core/version)
+(test -e /sys/module/ext4/version)
+(test -e /sys/module/jbd2/version)
+(test -e /sys/module/mbcache/version)
+(test -e /sys/module/xen_blkfront/version)
+(test -e /sys/module/pata_acpi/version)
+(cat /sys/module/pata_acpi/version || echo -n)
+(test -e /sys/module/ata_generic/version)
+(cat /sys/module/ata_generic/version || echo -n)
+(test -e /sys/module/ata_piix/version)
+(cat /sys/module/ata_piix/version || echo -n)
+(test -e /sys/module/dm_mirror/version)
+(test -e /sys/module/dm_region_hash/version)
+(test -e /sys/module/dm_log/version)
+(test -e /sys/module/dm_mod/version)
+(test -e /usr/bin/lsb_release)
+(test -e /etc/lsb-release)
+(test -e /etc/os-release)
+(test -e /etc/oracle-release)
+(test -e /etc/enterprise-release)
+(test -e /etc/f5-release)
+(test -e /etc/debian_version)
+(test -e /etc/parallels-release)
+(test -e /etc/Eos-release)
+(test -e /etc/redhat-release)
+(cat /etc/redhat-release || echo -n)
+(cat /proc/meminfo || echo -n)
+(which dmidecode)
+(echo $PATH)
+(stat -L /usr/local/bin/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/dmidecode 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(/usr/sbin/dmidecode)
+(hostname -s)
+(hostname)
+(hostname --fqdn)
+(hostname --fqdn)
+(test -e /proc/1/comm)
+(cat /proc/1/comm || echo -n)
+(VBoxControl guestproperty enumerate)
+(date +%Z)
+(xenstore-read vm-data/provider_data/provider)
+(test -e /sys/hypervisor/uuid)
+(cat /sys/hypervisor/uuid || echo -n)
+(curl -Is 169.254.169.254:80 --connect-timeout 2)
+(curl -i http://169.254.169.254:80/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/ami-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/ami-launch-index --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/ami-manifest-path --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/block-device-mapping/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/block-device-mapping/ami --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/block-device-mapping/root --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/hostname --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/instance-action --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/instance-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/instance-type --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/local-hostname --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/local-ipv4 --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/mac --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/metrics/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/metrics/vhostmd --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/device-number --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/interface-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/ipv4-associations/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/ipv4-associations/54.167.86.159 --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/local-hostname --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/local-ipv4s --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/mac --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/owner-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/public-hostname --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/public-ipv4s --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/security-group-ids --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/security-groups --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/subnet-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/subnet-ipv4-cidr-block --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/vpc-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/vpc-ipv4-cidr-block --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/network/interfaces/macs/0a:f3:15:99:19:36/vpc-ipv4-cidr-blocks --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/placement/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/placement/availability-zone --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/product-codes --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/profile --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/public-hostname --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/public-ipv4 --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/public-keys/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/public-keys/0/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/public-keys/0/openssh-key --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/reservation-id --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/security-groups --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/services/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/services/domain --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/meta-data/services/partition --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/user-data/ --keepalive-time 10)
+(curl -i http://169.254.169.254:80/2016-09-02/dynamic/instance-identity/document/ --keepalive-time 10)
+(cat /etc/passwd || echo -n)
+(cat /etc/group || echo -n)
+(which docker)
+(echo $PATH)
+(stat -L /usr/local/bin/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/docker 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:01:56-05:00] WARN: Plugin Virtualization: did not find docker
+(test -e /proc/xen)
+(test -e /proc/xen/capabilities)
+(test -e /proc/modules)
+(cat /proc/modules || echo -n)
+(which nova)
+(echo $PATH)
+(stat -L /usr/local/bin/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/nova 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:01:58-05:00] WARN: Plugin Virtualization: did not find nova
+(test -e /proc/cpuinfo)
+(cat /proc/cpuinfo || echo -n)
+(test -e /sys/devices/virtual/misc/kvm)
+(test -e /proc/bc/0)
+(test -e /proc/vz)
+(test -e /var/lib/hyperv/.kvp_pool_3)
+(test -e /proc/self/status)
+(cat /proc/self/status || echo -n)
+(test -e /proc/self/cgroup)
+(cat /proc/self/cgroup || echo -n)
+(stat -L /proc/self/cgroup 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(cat /proc/1/environ || echo -n)
+(stat -L /proc/1/environ 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(which lxc-version)
+(echo $PATH)
+(stat -L /usr/local/bin/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/lxc-version 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:02:01-05:00] WARN: Plugin Virtualization: did not find lxc-version
+(which lxc-start)
+(echo $PATH)
+(stat -L /usr/local/bin/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/lxc-start 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:02:03-05:00] WARN: Plugin Virtualization: did not find lxc-start
+(test -e /dev/lxd/sock)
+(test -e /var/lib/lxd/devlxd)
+(test -e /var/snap/lxd/common/lxd/devlxd)
+(test -e /etc/machine-id)
+(test -e /var/lib/dbus/machine-id)
+(test -e /etc/ssh/sshd_config)
+(cat /etc/ssh/sshd_config || echo -n)
+(test -e /etc/ssh/ssh_host_dsa_key.pub)
+(cat /etc/ssh/ssh_host_dsa_key.pub || echo -n)
+(test -e /etc/ssh/ssh_host_rsa_key.pub)
+(cat /etc/ssh/ssh_host_rsa_key.pub || echo -n)
+(test -e /etc/ssh/ssh_host_ecdsa_key.pub)
+(test -e /etc/ssh/ssh_host_ed25519_key.pub)
+(rpm -qa --qf '%{NAME}\t%|EPOCH?{%{EPOCH}}:{0}|\t%{VERSION}\t%{RELEASE}\t%{INSTALLTIME}\t%{ARCH}\n')
+(test -e /etc/shells)
+(cat /etc/shells || echo -n)
+(test -e /sys/class/dmi/id/product_name)
+(cat /sys/class/dmi/id/product_name || echo -n)
+(whoami)
+(docker info --format '{{json .}}')
+(test -e /proc/mdstat)
+(cat /proc/mdstat || echo -n)
+(test -e /sys/block)
+(ls -d /sys/block/*)
+(test -e /sys/block/loop0/size)
+(cat /sys/block/loop0/size || echo -n)
+(test -e /sys/block/loop0/removable)
+(cat /sys/block/loop0/removable || echo -n)
+(test -e /sys/block/loop0/device/model)
+(test -e /sys/block/loop0/device/rev)
+(test -e /sys/block/loop0/device/state)
+(test -e /sys/block/loop0/device/timeout)
+(test -e /sys/block/loop0/device/vendor)
+(test -e /sys/block/loop0/device/queue_depth)
+(test -e /sys/block/loop0/queue/rotational)
+(cat /sys/block/loop0/queue/rotational || echo -n)
+(test -e /sys/block/loop0/queue/physical_block_size)
+(cat /sys/block/loop0/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop0/queue/logical_block_size)
+(cat /sys/block/loop0/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop1/size)
+(cat /sys/block/loop1/size || echo -n)
+(test -e /sys/block/loop1/removable)
+(cat /sys/block/loop1/removable || echo -n)
+(test -e /sys/block/loop1/device/model)
+(test -e /sys/block/loop1/device/rev)
+(test -e /sys/block/loop1/device/state)
+(test -e /sys/block/loop1/device/timeout)
+(test -e /sys/block/loop1/device/vendor)
+(test -e /sys/block/loop1/device/queue_depth)
+(test -e /sys/block/loop1/queue/rotational)
+(cat /sys/block/loop1/queue/rotational || echo -n)
+(test -e /sys/block/loop1/queue/physical_block_size)
+(cat /sys/block/loop1/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop1/queue/logical_block_size)
+(cat /sys/block/loop1/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop2/size)
+(cat /sys/block/loop2/size || echo -n)
+(test -e /sys/block/loop2/removable)
+(cat /sys/block/loop2/removable || echo -n)
+(test -e /sys/block/loop2/device/model)
+(test -e /sys/block/loop2/device/rev)
+(test -e /sys/block/loop2/device/state)
+(test -e /sys/block/loop2/device/timeout)
+(test -e /sys/block/loop2/device/vendor)
+(test -e /sys/block/loop2/device/queue_depth)
+(test -e /sys/block/loop2/queue/rotational)
+(cat /sys/block/loop2/queue/rotational || echo -n)
+(test -e /sys/block/loop2/queue/physical_block_size)
+(cat /sys/block/loop2/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop2/queue/logical_block_size)
+(cat /sys/block/loop2/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop3/size)
+(cat /sys/block/loop3/size || echo -n)
+(test -e /sys/block/loop3/removable)
+(cat /sys/block/loop3/removable || echo -n)
+(test -e /sys/block/loop3/device/model)
+(test -e /sys/block/loop3/device/rev)
+(test -e /sys/block/loop3/device/state)
+(test -e /sys/block/loop3/device/timeout)
+(test -e /sys/block/loop3/device/vendor)
+(test -e /sys/block/loop3/device/queue_depth)
+(test -e /sys/block/loop3/queue/rotational)
+(cat /sys/block/loop3/queue/rotational || echo -n)
+(test -e /sys/block/loop3/queue/physical_block_size)
+(cat /sys/block/loop3/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop3/queue/logical_block_size)
+(cat /sys/block/loop3/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop4/size)
+(cat /sys/block/loop4/size || echo -n)
+(test -e /sys/block/loop4/removable)
+(cat /sys/block/loop4/removable || echo -n)
+(test -e /sys/block/loop4/device/model)
+(test -e /sys/block/loop4/device/rev)
+(test -e /sys/block/loop4/device/state)
+(test -e /sys/block/loop4/device/timeout)
+(test -e /sys/block/loop4/device/vendor)
+(test -e /sys/block/loop4/device/queue_depth)
+(test -e /sys/block/loop4/queue/rotational)
+(cat /sys/block/loop4/queue/rotational || echo -n)
+(test -e /sys/block/loop4/queue/physical_block_size)
+(cat /sys/block/loop4/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop4/queue/logical_block_size)
+(cat /sys/block/loop4/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop5/size)
+(cat /sys/block/loop5/size || echo -n)
+(test -e /sys/block/loop5/removable)
+(cat /sys/block/loop5/removable || echo -n)
+(test -e /sys/block/loop5/device/model)
+(test -e /sys/block/loop5/device/rev)
+(test -e /sys/block/loop5/device/state)
+(test -e /sys/block/loop5/device/timeout)
+(test -e /sys/block/loop5/device/vendor)
+(test -e /sys/block/loop5/device/queue_depth)
+(test -e /sys/block/loop5/queue/rotational)
+(cat /sys/block/loop5/queue/rotational || echo -n)
+(test -e /sys/block/loop5/queue/physical_block_size)
+(cat /sys/block/loop5/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop5/queue/logical_block_size)
+(cat /sys/block/loop5/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop6/size)
+(cat /sys/block/loop6/size || echo -n)
+(test -e /sys/block/loop6/removable)
+(cat /sys/block/loop6/removable || echo -n)
+(test -e /sys/block/loop6/device/model)
+(test -e /sys/block/loop6/device/rev)
+(test -e /sys/block/loop6/device/state)
+(test -e /sys/block/loop6/device/timeout)
+(test -e /sys/block/loop6/device/vendor)
+(test -e /sys/block/loop6/device/queue_depth)
+(test -e /sys/block/loop6/queue/rotational)
+(cat /sys/block/loop6/queue/rotational || echo -n)
+(test -e /sys/block/loop6/queue/physical_block_size)
+(cat /sys/block/loop6/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop6/queue/logical_block_size)
+(cat /sys/block/loop6/queue/logical_block_size || echo -n)
+(test -e /sys/block/loop7/size)
+(cat /sys/block/loop7/size || echo -n)
+(test -e /sys/block/loop7/removable)
+(cat /sys/block/loop7/removable || echo -n)
+(test -e /sys/block/loop7/device/model)
+(test -e /sys/block/loop7/device/rev)
+(test -e /sys/block/loop7/device/state)
+(test -e /sys/block/loop7/device/timeout)
+(test -e /sys/block/loop7/device/vendor)
+(test -e /sys/block/loop7/device/queue_depth)
+(test -e /sys/block/loop7/queue/rotational)
+(cat /sys/block/loop7/queue/rotational || echo -n)
+(test -e /sys/block/loop7/queue/physical_block_size)
+(cat /sys/block/loop7/queue/physical_block_size || echo -n)
+(test -e /sys/block/loop7/queue/logical_block_size)
+(cat /sys/block/loop7/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram0/size)
+(cat /sys/block/ram0/size || echo -n)
+(test -e /sys/block/ram0/removable)
+(cat /sys/block/ram0/removable || echo -n)
+(test -e /sys/block/ram0/device/model)
+(test -e /sys/block/ram0/device/rev)
+(test -e /sys/block/ram0/device/state)
+(test -e /sys/block/ram0/device/timeout)
+(test -e /sys/block/ram0/device/vendor)
+(test -e /sys/block/ram0/device/queue_depth)
+(test -e /sys/block/ram0/queue/rotational)
+(cat /sys/block/ram0/queue/rotational || echo -n)
+(test -e /sys/block/ram0/queue/physical_block_size)
+(cat /sys/block/ram0/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram0/queue/logical_block_size)
+(cat /sys/block/ram0/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram1/size)
+(cat /sys/block/ram1/size || echo -n)
+(test -e /sys/block/ram1/removable)
+(cat /sys/block/ram1/removable || echo -n)
+(test -e /sys/block/ram1/device/model)
+(test -e /sys/block/ram1/device/rev)
+(test -e /sys/block/ram1/device/state)
+(test -e /sys/block/ram1/device/timeout)
+(test -e /sys/block/ram1/device/vendor)
+(test -e /sys/block/ram1/device/queue_depth)
+(test -e /sys/block/ram1/queue/rotational)
+(cat /sys/block/ram1/queue/rotational || echo -n)
+(test -e /sys/block/ram1/queue/physical_block_size)
+(cat /sys/block/ram1/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram1/queue/logical_block_size)
+(cat /sys/block/ram1/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram10/size)
+(cat /sys/block/ram10/size || echo -n)
+(test -e /sys/block/ram10/removable)
+(cat /sys/block/ram10/removable || echo -n)
+(test -e /sys/block/ram10/device/model)
+(test -e /sys/block/ram10/device/rev)
+(test -e /sys/block/ram10/device/state)
+(test -e /sys/block/ram10/device/timeout)
+(test -e /sys/block/ram10/device/vendor)
+(test -e /sys/block/ram10/device/queue_depth)
+(test -e /sys/block/ram10/queue/rotational)
+(cat /sys/block/ram10/queue/rotational || echo -n)
+(test -e /sys/block/ram10/queue/physical_block_size)
+(cat /sys/block/ram10/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram10/queue/logical_block_size)
+(cat /sys/block/ram10/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram11/size)
+(cat /sys/block/ram11/size || echo -n)
+(test -e /sys/block/ram11/removable)
+(cat /sys/block/ram11/removable || echo -n)
+(test -e /sys/block/ram11/device/model)
+(test -e /sys/block/ram11/device/rev)
+(test -e /sys/block/ram11/device/state)
+(test -e /sys/block/ram11/device/timeout)
+(test -e /sys/block/ram11/device/vendor)
+(test -e /sys/block/ram11/device/queue_depth)
+(test -e /sys/block/ram11/queue/rotational)
+(cat /sys/block/ram11/queue/rotational || echo -n)
+(test -e /sys/block/ram11/queue/physical_block_size)
+(cat /sys/block/ram11/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram11/queue/logical_block_size)
+(cat /sys/block/ram11/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram12/size)
+(cat /sys/block/ram12/size || echo -n)
+(test -e /sys/block/ram12/removable)
+(cat /sys/block/ram12/removable || echo -n)
+(test -e /sys/block/ram12/device/model)
+(test -e /sys/block/ram12/device/rev)
+(test -e /sys/block/ram12/device/state)
+(test -e /sys/block/ram12/device/timeout)
+(test -e /sys/block/ram12/device/vendor)
+(test -e /sys/block/ram12/device/queue_depth)
+(test -e /sys/block/ram12/queue/rotational)
+(cat /sys/block/ram12/queue/rotational || echo -n)
+(test -e /sys/block/ram12/queue/physical_block_size)
+(cat /sys/block/ram12/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram12/queue/logical_block_size)
+(cat /sys/block/ram12/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram13/size)
+(cat /sys/block/ram13/size || echo -n)
+(test -e /sys/block/ram13/removable)
+(cat /sys/block/ram13/removable || echo -n)
+(test -e /sys/block/ram13/device/model)
+(test -e /sys/block/ram13/device/rev)
+(test -e /sys/block/ram13/device/state)
+(test -e /sys/block/ram13/device/timeout)
+(test -e /sys/block/ram13/device/vendor)
+(test -e /sys/block/ram13/device/queue_depth)
+(test -e /sys/block/ram13/queue/rotational)
+(cat /sys/block/ram13/queue/rotational || echo -n)
+(test -e /sys/block/ram13/queue/physical_block_size)
+(cat /sys/block/ram13/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram13/queue/logical_block_size)
+(cat /sys/block/ram13/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram14/size)
+(cat /sys/block/ram14/size || echo -n)
+(test -e /sys/block/ram14/removable)
+(cat /sys/block/ram14/removable || echo -n)
+(test -e /sys/block/ram14/device/model)
+(test -e /sys/block/ram14/device/rev)
+(test -e /sys/block/ram14/device/state)
+(test -e /sys/block/ram14/device/timeout)
+(test -e /sys/block/ram14/device/vendor)
+(test -e /sys/block/ram14/device/queue_depth)
+(test -e /sys/block/ram14/queue/rotational)
+(cat /sys/block/ram14/queue/rotational || echo -n)
+(test -e /sys/block/ram14/queue/physical_block_size)
+(cat /sys/block/ram14/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram14/queue/logical_block_size)
+(cat /sys/block/ram14/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram15/size)
+(cat /sys/block/ram15/size || echo -n)
+(test -e /sys/block/ram15/removable)
+(cat /sys/block/ram15/removable || echo -n)
+(test -e /sys/block/ram15/device/model)
+(test -e /sys/block/ram15/device/rev)
+(test -e /sys/block/ram15/device/state)
+(test -e /sys/block/ram15/device/timeout)
+(test -e /sys/block/ram15/device/vendor)
+(test -e /sys/block/ram15/device/queue_depth)
+(test -e /sys/block/ram15/queue/rotational)
+(cat /sys/block/ram15/queue/rotational || echo -n)
+(test -e /sys/block/ram15/queue/physical_block_size)
+(cat /sys/block/ram15/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram15/queue/logical_block_size)
+(cat /sys/block/ram15/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram2/size)
+(cat /sys/block/ram2/size || echo -n)
+(test -e /sys/block/ram2/removable)
+(cat /sys/block/ram2/removable || echo -n)
+(test -e /sys/block/ram2/device/model)
+(test -e /sys/block/ram2/device/rev)
+(test -e /sys/block/ram2/device/state)
+(test -e /sys/block/ram2/device/timeout)
+(test -e /sys/block/ram2/device/vendor)
+(test -e /sys/block/ram2/device/queue_depth)
+(test -e /sys/block/ram2/queue/rotational)
+(cat /sys/block/ram2/queue/rotational || echo -n)
+(test -e /sys/block/ram2/queue/physical_block_size)
+(cat /sys/block/ram2/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram2/queue/logical_block_size)
+(cat /sys/block/ram2/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram3/size)
+(cat /sys/block/ram3/size || echo -n)
+(test -e /sys/block/ram3/removable)
+(cat /sys/block/ram3/removable || echo -n)
+(test -e /sys/block/ram3/device/model)
+(test -e /sys/block/ram3/device/rev)
+(test -e /sys/block/ram3/device/state)
+(test -e /sys/block/ram3/device/timeout)
+(test -e /sys/block/ram3/device/vendor)
+(test -e /sys/block/ram3/device/queue_depth)
+(test -e /sys/block/ram3/queue/rotational)
+(cat /sys/block/ram3/queue/rotational || echo -n)
+(test -e /sys/block/ram3/queue/physical_block_size)
+(cat /sys/block/ram3/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram3/queue/logical_block_size)
+(cat /sys/block/ram3/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram4/size)
+(cat /sys/block/ram4/size || echo -n)
+(test -e /sys/block/ram4/removable)
+(cat /sys/block/ram4/removable || echo -n)
+(test -e /sys/block/ram4/device/model)
+(test -e /sys/block/ram4/device/rev)
+(test -e /sys/block/ram4/device/state)
+(test -e /sys/block/ram4/device/timeout)
+(test -e /sys/block/ram4/device/vendor)
+(test -e /sys/block/ram4/device/queue_depth)
+(test -e /sys/block/ram4/queue/rotational)
+(cat /sys/block/ram4/queue/rotational || echo -n)
+(test -e /sys/block/ram4/queue/physical_block_size)
+(cat /sys/block/ram4/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram4/queue/logical_block_size)
+(cat /sys/block/ram4/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram5/size)
+(cat /sys/block/ram5/size || echo -n)
+(test -e /sys/block/ram5/removable)
+(cat /sys/block/ram5/removable || echo -n)
+(test -e /sys/block/ram5/device/model)
+(test -e /sys/block/ram5/device/rev)
+(test -e /sys/block/ram5/device/state)
+(test -e /sys/block/ram5/device/timeout)
+(test -e /sys/block/ram5/device/vendor)
+(test -e /sys/block/ram5/device/queue_depth)
+(test -e /sys/block/ram5/queue/rotational)
+(cat /sys/block/ram5/queue/rotational || echo -n)
+(test -e /sys/block/ram5/queue/physical_block_size)
+(cat /sys/block/ram5/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram5/queue/logical_block_size)
+(cat /sys/block/ram5/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram6/size)
+(cat /sys/block/ram6/size || echo -n)
+(test -e /sys/block/ram6/removable)
+(cat /sys/block/ram6/removable || echo -n)
+(test -e /sys/block/ram6/device/model)
+(test -e /sys/block/ram6/device/rev)
+(test -e /sys/block/ram6/device/state)
+(test -e /sys/block/ram6/device/timeout)
+(test -e /sys/block/ram6/device/vendor)
+(test -e /sys/block/ram6/device/queue_depth)
+(test -e /sys/block/ram6/queue/rotational)
+(cat /sys/block/ram6/queue/rotational || echo -n)
+(test -e /sys/block/ram6/queue/physical_block_size)
+(cat /sys/block/ram6/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram6/queue/logical_block_size)
+(cat /sys/block/ram6/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram7/size)
+(cat /sys/block/ram7/size || echo -n)
+(test -e /sys/block/ram7/removable)
+(cat /sys/block/ram7/removable || echo -n)
+(test -e /sys/block/ram7/device/model)
+(test -e /sys/block/ram7/device/rev)
+(test -e /sys/block/ram7/device/state)
+(test -e /sys/block/ram7/device/timeout)
+(test -e /sys/block/ram7/device/vendor)
+(test -e /sys/block/ram7/device/queue_depth)
+(test -e /sys/block/ram7/queue/rotational)
+(cat /sys/block/ram7/queue/rotational || echo -n)
+(test -e /sys/block/ram7/queue/physical_block_size)
+(cat /sys/block/ram7/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram7/queue/logical_block_size)
+(cat /sys/block/ram7/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram8/size)
+(cat /sys/block/ram8/size || echo -n)
+(test -e /sys/block/ram8/removable)
+(cat /sys/block/ram8/removable || echo -n)
+(test -e /sys/block/ram8/device/model)
+(test -e /sys/block/ram8/device/rev)
+(test -e /sys/block/ram8/device/state)
+(test -e /sys/block/ram8/device/timeout)
+(test -e /sys/block/ram8/device/vendor)
+(test -e /sys/block/ram8/device/queue_depth)
+(test -e /sys/block/ram8/queue/rotational)
+(cat /sys/block/ram8/queue/rotational || echo -n)
+(test -e /sys/block/ram8/queue/physical_block_size)
+(cat /sys/block/ram8/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram8/queue/logical_block_size)
+(cat /sys/block/ram8/queue/logical_block_size || echo -n)
+(test -e /sys/block/ram9/size)
+(cat /sys/block/ram9/size || echo -n)
+(test -e /sys/block/ram9/removable)
+(cat /sys/block/ram9/removable || echo -n)
+(test -e /sys/block/ram9/device/model)
+(test -e /sys/block/ram9/device/rev)
+(test -e /sys/block/ram9/device/state)
+(test -e /sys/block/ram9/device/timeout)
+(test -e /sys/block/ram9/device/vendor)
+(test -e /sys/block/ram9/device/queue_depth)
+(test -e /sys/block/ram9/queue/rotational)
+(cat /sys/block/ram9/queue/rotational || echo -n)
+(test -e /sys/block/ram9/queue/physical_block_size)
+(cat /sys/block/ram9/queue/physical_block_size || echo -n)
+(test -e /sys/block/ram9/queue/logical_block_size)
+(cat /sys/block/ram9/queue/logical_block_size || echo -n)
+(test -e /sys/block/xvda/size)
+(cat /sys/block/xvda/size || echo -n)
+(test -e /sys/block/xvda/removable)
+(cat /sys/block/xvda/removable || echo -n)
+(test -e /sys/block/xvda/device/model)
+(test -e /sys/block/xvda/device/rev)
+(test -e /sys/block/xvda/device/state)
+(test -e /sys/block/xvda/device/timeout)
+(test -e /sys/block/xvda/device/vendor)
+(test -e /sys/block/xvda/device/queue_depth)
+(test -e /sys/block/xvda/queue/rotational)
+(cat /sys/block/xvda/queue/rotational || echo -n)
+(test -e /sys/block/xvda/queue/physical_block_size)
+(cat /sys/block/xvda/queue/physical_block_size || echo -n)
+(test -e /sys/block/xvda/queue/logical_block_size)
+(cat /sys/block/xvda/queue/logical_block_size || echo -n)
+(which hostnamectl)
+(echo $PATH)
+(stat -L /usr/local/bin/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/sbin/hostnamectl 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+[2019-04-03T23:03:15-05:00] WARN: Plugin Hostnamectl: did not find hostnamectl
+(hostnamectl)
+(cat /proc/cmdline || echo -n)
+(zpool list -H -o name,size,alloc,free,cap,dedup,health,version)
+(test -e /usr/sbin/waagent)
+(test -e C:\\WindowsAzure)
+(test -e /var/lib/dhcp/dhclient.eth0.leases)
+(df -P)
+(df -iP)
+(mount)
+(which lsblk)
+(which blkid)
+(echo $PATH)
+(stat -L /usr/local/bin/blkid 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /bin/blkid 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin'
+'/blkid 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /usr/bin/blkid 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(stat -L /sbin/blkid 2>/dev/null --printf '%s
+%f
+%U
+%u
+%G
+%g
+%X
+%Y
+%C')
+(/bin/lsblk -n -P -o NAME,UUID,LABEL,FSTYPE)
+(test -e /dev/xvda)
+(test -e /dev/xvda1)
+(/sbin/blkid)
+(test -e /proc/mounts)
+(cat /proc/mounts || echo -n)
+(which getconf)
+(/usr/bin/getconf -a)

--- a/scans/centos-ec2-original.json
+++ b/scans/centos-ec2-original.json
@@ -1,0 +1,3408 @@
+{
+	"block_device": {
+		"ram0": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram1": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram2": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram3": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram4": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram5": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram6": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram7": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram8": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram9": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram10": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram11": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram12": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram13": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram14": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram15": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop0": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop1": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop2": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop3": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop4": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop5": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop6": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop7": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"xvda": {
+			"size": "16777216",
+			"removable": "0",
+			"rotational": "0",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		}
+	},
+	"chef_packages": {
+		"ohai": {
+			"version": "14.8.10",
+			"ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/ohai-14.8.10/lib/ohai"
+		}
+	},
+	"cloud": {
+		"public_ipv4_addrs": [
+			"54.198.76.193"
+		],
+		"local_ipv4_addrs": [
+			"172.30.0.123"
+		],
+		"provider": "ec2",
+		"public_hostname": "",
+		"local_hostname": "ip-172-30-0-123.ec2.internal",
+		"public_ipv4": "54.198.76.193",
+		"local_ipv4": "172.30.0.123"
+	},
+	"command": {
+		"ps": "ps -ef"
+	},
+	"counters": {
+		"network": {
+			"interfaces": {
+				"lo": {
+					"rx": {
+						"bytes": "0",
+						"packets": "0",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					},
+					"tx": {
+						"bytes": "0",
+						"packets": "0",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					}
+				},
+				"eth0": {
+					"tx": {
+						"queuelen": "1000",
+						"bytes": "1278968",
+						"packets": "13898",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "32421958",
+						"packets": "24379",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				}
+			}
+		}
+	},
+	"cpu": {
+		"0": {
+			"vendor_id": "GenuineIntel",
+			"family": "6",
+			"model": "63",
+			"model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+			"stepping": "2",
+			"mhz": "2400.062",
+			"cache_size": "30720 KB",
+			"physical_id": "0",
+			"core_id": "0",
+			"cores": "1",
+			"flags": [
+				"fpu",
+				"vme",
+				"de",
+				"pse",
+				"tsc",
+				"msr",
+				"pae",
+				"mce",
+				"cx8",
+				"apic",
+				"sep",
+				"mtrr",
+				"pge",
+				"mca",
+				"cmov",
+				"pat",
+				"pse36",
+				"clflush",
+				"mmx",
+				"fxsr",
+				"sse",
+				"sse2",
+				"ht",
+				"syscall",
+				"nx",
+				"rdtscp",
+				"lm",
+				"constant_tsc",
+				"up",
+				"rep_good",
+				"xtopology",
+				"unfair_spinlock",
+				"eagerfpu",
+				"pni",
+				"pclmulqdq",
+				"ssse3",
+				"fma",
+				"cx16",
+				"pcid",
+				"sse4_1",
+				"sse4_2",
+				"x2apic",
+				"movbe",
+				"popcnt",
+				"tsc_deadline_timer",
+				"aes",
+				"xsave",
+				"avx",
+				"f16c",
+				"rdrand",
+				"hypervisor",
+				"lahf_lm",
+				"abm",
+				"xsaveopt",
+				"invpcid_single",
+				"pti",
+				"retpoline",
+				"fsgsbase",
+				"bmi1",
+				"avx2",
+				"smep",
+				"bmi2",
+				"erms",
+				"invpcid"
+			]
+		},
+		"total": 1,
+		"real": 1,
+		"cores": 1
+	},
+	"current_user": "centos",
+	"dmi": {
+		"dmidecode_version": "2.12"
+	},
+	"domain": null,
+	"ec2": {
+		"ami_id": "ami-014b38e758721be30",
+		"ami_launch_index": "0",
+		"ami_manifest_path": "(unknown)",
+		"block_device_mapping_ami": "/dev/sda1",
+		"block_device_mapping_root": "/dev/sda1",
+		"hostname": "ip-172-30-0-123.ec2.internal",
+		"instance_action": "none",
+		"instance_id": "i-09179632fe056f568",
+		"instance_type": "t2.micro",
+		"local_hostname": "ip-172-30-0-123.ec2.internal",
+		"local_ipv4": "172.30.0.123",
+		"mac": "0a:ae:4e:50:46:fe",
+		"metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+		"network_interfaces_macs": {
+			"0a:ae:4e:50:46:fe": {
+				"device_number": "0",
+				"interface_id": "eni-08946a0b85f537cb9",
+				"ipv4-associations": {
+					"54.198.76.193": "172.30.0.123"
+				},
+				"local_hostname": "ip-172-30-0-123.ec2.internal",
+				"local_ipv4s": "172.30.0.123",
+				"mac": "0a:ae:4e:50:46:fe",
+				"owner_id": "399524901138",
+				"public_hostname": "",
+				"public_ipv4s": "54.198.76.193",
+				"security_group_ids": "sg-c7086ca3",
+				"security_groups": "launch-wizard-1",
+				"subnet_id": "subnet-49b5d63e",
+				"subnet_ipv4_cidr_block": "172.30.0.0/24",
+				"vpc_id": "vpc-02550367",
+				"vpc_ipv4_cidr_block": "172.30.0.0/16",
+				"vpc_ipv4_cidr_blocks": "172.30.0.0/16"
+			}
+		},
+		"placement_availability_zone": "us-east-1a",
+		"product_codes": "6x5jmcajty9edm3f211pqjfn2",
+		"profile": "default-hvm",
+		"public_hostname": "",
+		"public_ipv4": "54.198.76.193",
+		"public_keys_0_openssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiezJPkkl7W6lXMfl3x7oEs6ahrR8W35zLGxQRsnq99ShKpZnB+X20wlskUQt8PpXE+3rersJwA8euF5lTiml53K/ojM190FZAiwgvYjLe0yB/mtP8nPzh5h2G6U6Iu7eNV0C2f+rzvzy7LM8W6t8ULpS+W48Va2teVD7927BMwWVzL1g4iLRvRnOHpYkVlO9KbzUzO2mDW8giT8tRQyc7hDBiJClLxxr+hUu7i/8Rfq2esTp2aXRyvpVycfExTKGotVcLYd4+f3VH2Lmf4mR5SckGXGyym/VUOl6uaRDoTijTaf3DDL3sZiZBTEdihGidt3hlysbum2HfWKfxbGgr ohai\n",
+		"reservation_id": "r-057541d9abe0db0bb",
+		"security_groups": [
+			"launch-wizard-1"
+		],
+		"services_domain": "amazonaws.com",
+		"services_partition": "aws",
+		"userdata": null,
+		"account_id": "399524901138",
+		"availability_zone": "us-east-1a",
+		"region": "us-east-1"
+	},
+	"etc": {
+		"passwd": {
+			"root": {
+				"dir": "/root",
+				"gid": 0,
+				"uid": 0,
+				"shell": "/bin/bash",
+				"gecos": "root"
+			},
+			"bin": {
+				"dir": "/bin",
+				"gid": 1,
+				"uid": 1,
+				"shell": "/sbin/nologin",
+				"gecos": "bin"
+			},
+			"daemon": {
+				"dir": "/sbin",
+				"gid": 2,
+				"uid": 2,
+				"shell": "/sbin/nologin",
+				"gecos": "daemon"
+			},
+			"adm": {
+				"dir": "/var/adm",
+				"gid": 4,
+				"uid": 3,
+				"shell": "/sbin/nologin",
+				"gecos": "adm"
+			},
+			"lp": {
+				"dir": "/var/spool/lpd",
+				"gid": 7,
+				"uid": 4,
+				"shell": "/sbin/nologin",
+				"gecos": "lp"
+			},
+			"sync": {
+				"dir": "/sbin",
+				"gid": 0,
+				"uid": 5,
+				"shell": "/bin/sync",
+				"gecos": "sync"
+			},
+			"shutdown": {
+				"dir": "/sbin",
+				"gid": 0,
+				"uid": 6,
+				"shell": "/sbin/shutdown",
+				"gecos": "shutdown"
+			},
+			"halt": {
+				"dir": "/sbin",
+				"gid": 0,
+				"uid": 7,
+				"shell": "/sbin/halt",
+				"gecos": "halt"
+			},
+			"mail": {
+				"dir": "/var/spool/mail",
+				"gid": 12,
+				"uid": 8,
+				"shell": "/sbin/nologin",
+				"gecos": "mail"
+			},
+			"uucp": {
+				"dir": "/var/spool/uucp",
+				"gid": 14,
+				"uid": 10,
+				"shell": "/sbin/nologin",
+				"gecos": "uucp"
+			},
+			"operator": {
+				"dir": "/root",
+				"gid": 0,
+				"uid": 11,
+				"shell": "/sbin/nologin",
+				"gecos": "operator"
+			},
+			"games": {
+				"dir": "/usr/games",
+				"gid": 100,
+				"uid": 12,
+				"shell": "/sbin/nologin",
+				"gecos": "games"
+			},
+			"gopher": {
+				"dir": "/var/gopher",
+				"gid": 30,
+				"uid": 13,
+				"shell": "/sbin/nologin",
+				"gecos": "gopher"
+			},
+			"ftp": {
+				"dir": "/var/ftp",
+				"gid": 50,
+				"uid": 14,
+				"shell": "/sbin/nologin",
+				"gecos": "FTP User"
+			},
+			"nobody": {
+				"dir": "/",
+				"gid": 99,
+				"uid": 99,
+				"shell": "/sbin/nologin",
+				"gecos": "Nobody"
+			},
+			"vcsa": {
+				"dir": "/dev",
+				"gid": 69,
+				"uid": 69,
+				"shell": "/sbin/nologin",
+				"gecos": "virtual console memory owner"
+			},
+			"saslauth": {
+				"dir": "/var/empty/saslauth",
+				"gid": 76,
+				"uid": 499,
+				"shell": "/sbin/nologin",
+				"gecos": "Saslauthd user"
+			},
+			"postfix": {
+				"dir": "/var/spool/postfix",
+				"gid": 89,
+				"uid": 89,
+				"shell": "/sbin/nologin",
+				"gecos": ""
+			},
+			"sshd": {
+				"dir": "/var/empty/sshd",
+				"gid": 74,
+				"uid": 74,
+				"shell": "/sbin/nologin",
+				"gecos": "Privilege-separated SSH"
+			},
+			"centos": {
+				"dir": "/home/centos",
+				"gid": 500,
+				"uid": 500,
+				"shell": "/bin/bash",
+				"gecos": "Cloud User"
+			}
+		},
+		"group": {
+			"root": {
+				"gid": 0,
+				"members": []
+			},
+			"bin": {
+				"gid": 1,
+				"members": [
+					"bin",
+					"daemon"
+				]
+			},
+			"daemon": {
+				"gid": 2,
+				"members": [
+					"bin",
+					"daemon"
+				]
+			},
+			"sys": {
+				"gid": 3,
+				"members": [
+					"bin",
+					"adm"
+				]
+			},
+			"adm": {
+				"gid": 4,
+				"members": [
+					"adm",
+					"daemon",
+					"centos"
+				]
+			},
+			"tty": {
+				"gid": 5,
+				"members": []
+			},
+			"disk": {
+				"gid": 6,
+				"members": []
+			},
+			"lp": {
+				"gid": 7,
+				"members": [
+					"daemon"
+				]
+			},
+			"mem": {
+				"gid": 8,
+				"members": []
+			},
+			"kmem": {
+				"gid": 9,
+				"members": []
+			},
+			"wheel": {
+				"gid": 10,
+				"members": [
+					"centos"
+				]
+			},
+			"mail": {
+				"gid": 12,
+				"members": [
+					"mail",
+					"postfix"
+				]
+			},
+			"uucp": {
+				"gid": 14,
+				"members": []
+			},
+			"man": {
+				"gid": 15,
+				"members": []
+			},
+			"games": {
+				"gid": 20,
+				"members": []
+			},
+			"gopher": {
+				"gid": 30,
+				"members": []
+			},
+			"video": {
+				"gid": 39,
+				"members": []
+			},
+			"dip": {
+				"gid": 40,
+				"members": []
+			},
+			"ftp": {
+				"gid": 50,
+				"members": []
+			},
+			"lock": {
+				"gid": 54,
+				"members": []
+			},
+			"audio": {
+				"gid": 63,
+				"members": []
+			},
+			"nobody": {
+				"gid": 99,
+				"members": []
+			},
+			"users": {
+				"gid": 100,
+				"members": []
+			},
+			"utmp": {
+				"gid": 22,
+				"members": []
+			},
+			"utempter": {
+				"gid": 35,
+				"members": []
+			},
+			"floppy": {
+				"gid": 19,
+				"members": []
+			},
+			"vcsa": {
+				"gid": 69,
+				"members": []
+			},
+			"cdrom": {
+				"gid": 11,
+				"members": []
+			},
+			"tape": {
+				"gid": 33,
+				"members": []
+			},
+			"dialout": {
+				"gid": 18,
+				"members": []
+			},
+			"saslauth": {
+				"gid": 76,
+				"members": []
+			},
+			"postdrop": {
+				"gid": 90,
+				"members": []
+			},
+			"postfix": {
+				"gid": 89,
+				"members": []
+			},
+			"cgred": {
+				"gid": 499,
+				"members": []
+			},
+			"sshd": {
+				"gid": 74,
+				"members": []
+			},
+			"centos": {
+				"gid": 500,
+				"members": []
+			}
+		}
+	},
+	"filesystem": {
+		"by_device": {
+			"/dev/xvda1": {
+				"kb_size": "8124856",
+				"kb_used": "881068",
+				"kb_available": "6824412",
+				"percent_used": "12%",
+				"total_inodes": "524288",
+				"inodes_used": "34014",
+				"inodes_available": "490274",
+				"inodes_percent_used": "7%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c",
+				"mounts": [
+					"/"
+				]
+			},
+			"tmpfs": {
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				],
+				"mounts": [
+					"/dev/shm"
+				]
+			},
+			"proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/proc"
+				]
+			},
+			"sysfs": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/sys"
+				]
+			},
+			"devpts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				],
+				"mounts": [
+					"/dev/pts"
+				]
+			},
+			"none": {
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/proc/sys/fs/binfmt_misc",
+					"/selinux"
+				]
+			},
+			"/dev/xvda": {
+				"mounts": []
+			},
+			"rootfs": {
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/"
+				]
+			},
+			"devtmpfs": {
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				],
+				"mounts": [
+					"/dev"
+				]
+			},
+			"/proc/bus/usb": {
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/proc/bus/usb"
+				]
+			}
+		},
+		"by_mountpoint": {
+			"/": {
+				"kb_size": "8124856",
+				"kb_used": "881068",
+				"kb_available": "6824412",
+				"percent_used": "12%",
+				"total_inodes": "524288",
+				"inodes_used": "34014",
+				"inodes_available": "490274",
+				"inodes_percent_used": "7%",
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c",
+				"devices": [
+					"/dev/xvda1",
+					"rootfs"
+				]
+			},
+			"/dev/shm": {
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"proc"
+				]
+			},
+			"/sys": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"sysfs"
+				]
+			},
+			"/dev/pts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				],
+				"devices": [
+					"devpts"
+				]
+			},
+			"/proc/sys/fs/binfmt_misc": {
+				"fs_type": "binfmt_misc",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"none"
+				]
+			},
+			"/dev": {
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				],
+				"devices": [
+					"devtmpfs"
+				]
+			},
+			"/selinux": {
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"none"
+				]
+			},
+			"/proc/bus/usb": {
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"/proc/bus/usb"
+				]
+			}
+		},
+		"by_pair": {
+			"/dev/xvda1,/": {
+				"device": "/dev/xvda1",
+				"kb_size": "8124856",
+				"kb_used": "881068",
+				"kb_available": "6824412",
+				"percent_used": "12%",
+				"mount": "/",
+				"total_inodes": "524288",
+				"inodes_used": "34014",
+				"inodes_available": "490274",
+				"inodes_percent_used": "7%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c"
+			},
+			"tmpfs,/dev/shm": {
+				"device": "tmpfs",
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"mount": "/dev/shm",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				]
+			},
+			"proc,/proc": {
+				"device": "proc",
+				"mount": "/proc",
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"sysfs,/sys": {
+				"device": "sysfs",
+				"mount": "/sys",
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"devpts,/dev/pts": {
+				"device": "devpts",
+				"mount": "/dev/pts",
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				]
+			},
+			"none,/proc/sys/fs/binfmt_misc": {
+				"device": "none",
+				"mount": "/proc/sys/fs/binfmt_misc",
+				"fs_type": "binfmt_misc",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"/dev/xvda,": {
+				"device": "/dev/xvda"
+			},
+			"rootfs,/": {
+				"device": "rootfs",
+				"mount": "/",
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"devtmpfs,/dev": {
+				"device": "devtmpfs",
+				"mount": "/dev",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				]
+			},
+			"none,/selinux": {
+				"device": "none",
+				"mount": "/selinux",
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"/proc/bus/usb,/proc/bus/usb": {
+				"device": "/proc/bus/usb",
+				"mount": "/proc/bus/usb",
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			}
+		}
+	},
+	"fips": {
+		"kernel": {
+			"enabled": false
+		}
+	},
+	"hostname": "ip-172-30-0-123",
+	"hostnamectl": {},
+	"idletime": "31 minutes 58 seconds",
+	"idletime_seconds": 1918,
+	"init_package": "init",
+	"ip6address": "fe80::8ae:4eff:fe50:46fe",
+	"ipaddress": "172.30.0.123",
+	"json?": "{\n  \"devpayProductCodes\" : null,\n  \"marketplaceProductCodes\" : [ \"6x5jmcajty9edm3f211pqjfn2\" ],\n  \"version\" : \"2017-09-30\",\n  \"instanceType\" : \"t2.micro\",\n  \"billingProducts\" : null,\n  \"instanceId\" : \"i-09179632fe056f568\",\n  \"imageId\" : \"ami-014b38e758721be30\",\n  \"pendingTime\" : \"2019-03-31T04:34:19Z\",\n  \"accountId\" : \"399524901138\",\n  \"availabilityZone\" : \"us-east-1a\",\n  \"kernelId\" : null,\n  \"ramdiskId\" : null,\n  \"architecture\" : \"x86_64\",\n  \"privateIp\" : \"172.30.0.123\",\n  \"region\" : \"us-east-1\"\n}",
+	"kernel": {
+		"name": "Linux",
+		"release": "2.6.32-754.10.1.el6.x86_64",
+		"version": "#1 SMP Tue Jan 15 17:07:28 UTC 2019",
+		"machine": "x86_64",
+		"processor": "x86_64",
+		"os": "GNU/Linux",
+		"modules": {
+			"ipt_REJECT": {
+				"size": "2383",
+				"refcount": "2"
+			},
+			"nf_conntrack_ipv4": {
+				"size": "9218",
+				"refcount": "2"
+			},
+			"nf_defrag_ipv4": {
+				"size": "1483",
+				"refcount": "1"
+			},
+			"iptable_filter": {
+				"size": "2793",
+				"refcount": "1"
+			},
+			"ip_tables": {
+				"size": "17895",
+				"refcount": "1"
+			},
+			"ip6t_REJECT": {
+				"size": "4372",
+				"refcount": "2"
+			},
+			"nf_conntrack_ipv6": {
+				"size": "7985",
+				"refcount": "3"
+			},
+			"nf_defrag_ipv6": {
+				"size": "26637",
+				"refcount": "1"
+			},
+			"xt_state": {
+				"size": "1492",
+				"refcount": "5"
+			},
+			"nf_conntrack": {
+				"size": "79761",
+				"refcount": "3"
+			},
+			"ip6table_filter": {
+				"size": "2889",
+				"refcount": "1"
+			},
+			"ip6_tables": {
+				"size": "18828",
+				"refcount": "1"
+			},
+			"ib_ipoib": {
+				"size": "81191",
+				"refcount": "0",
+				"version": "1.0.0"
+			},
+			"rdma_ucm": {
+				"size": "15739",
+				"refcount": "0"
+			},
+			"ib_ucm": {
+				"size": "12360",
+				"refcount": "0"
+			},
+			"ib_uverbs": {
+				"size": "40564",
+				"refcount": "2"
+			},
+			"ib_umad": {
+				"size": "13519",
+				"refcount": "0"
+			},
+			"rdma_cm": {
+				"size": "36651",
+				"refcount": "1"
+			},
+			"ib_cm": {
+				"size": "37444",
+				"refcount": "3"
+			},
+			"iw_cm": {
+				"size": "33136",
+				"refcount": "1"
+			},
+			"ib_sa": {
+				"size": "24188",
+				"refcount": "4"
+			},
+			"ib_mad": {
+				"size": "41628",
+				"refcount": "3"
+			},
+			"ib_core": {
+				"size": "83376",
+				"refcount": "10"
+			},
+			"ib_addr": {
+				"size": "8304",
+				"refcount": "3"
+			},
+			"ipv6": {
+				"size": "337436",
+				"refcount": "45"
+			},
+			"xen_netfront": {
+				"size": "18930",
+				"refcount": "0"
+			},
+			"i2c_piix4": {
+				"size": "11520",
+				"refcount": "0"
+			},
+			"i2c_core": {
+				"size": "29164",
+				"refcount": "1"
+			},
+			"ext4": {
+				"size": "381616",
+				"refcount": "1"
+			},
+			"jbd2": {
+				"size": "93380",
+				"refcount": "1"
+			},
+			"mbcache": {
+				"size": "8193",
+				"refcount": "1"
+			},
+			"xen_blkfront": {
+				"size": "21966",
+				"refcount": "2"
+			},
+			"pata_acpi": {
+				"size": "3701",
+				"refcount": "0",
+				"version": "0.2.3"
+			},
+			"ata_generic": {
+				"size": "3837",
+				"refcount": "0",
+				"version": "0.2.15"
+			},
+			"ata_piix": {
+				"size": "24409",
+				"refcount": "0",
+				"version": "2.13"
+			},
+			"dm_mirror": {
+				"size": "14864",
+				"refcount": "0"
+			},
+			"dm_region_hash": {
+				"size": "12181",
+				"refcount": "1"
+			},
+			"dm_log": {
+				"size": "9930",
+				"refcount": "2"
+			},
+			"dm_mod": {
+				"size": "102823",
+				"refcount": "2"
+			}
+		}
+	},
+	"keys": {
+		"ssh": {
+			"host_dsa_public": "AAAAB3NzaC1kc3MAAACBALdYNom0dDTn2dt/GaUKI7vLG2Ug4Gytt6cVU7RjfSnaKiiYPBpthSQOmwJxZ+rl/bRrQmJWfEqLbWWHgULYFEAadfFO9o5b101THhs5nB3Hq5MOVbXLJuJYeq9hHYaATeGWX682UnaHRpDeKBam3Yj26gruFcGCqDfGI3fTOKcvAAAAFQCkxQxP2Tem6r6SXwqXbY5Zm7ES9QAAAIEAjtGM60wtSPsl6Au8Xizmxp6TZ5ER8ciaaXLTmjVvbqmVMUzXqzXarFf2Y480wWc3WAzLcQ65t5HcT4nQ8PNI+j23gYNqS7Be4VNg/V1dXp1IRg3jsBtBwM7cvqLNuVqkZiQx1yGz6BE8Y667uqIEKRBG0BDa6t44FrjXFuy/RY4AAACBALDtmIejh8AmCpL02kNoi0ujIUesbpIVW/7UOefvrCgGIvCrM3J3UVMUBhj51rMiRVp6fbHyme4tQ/knP8wbR75cQSBUHkdXnRe5CZVhgt3jm7VKfKNlMl4n4B3QHwvAnxAxjI1fkFlHaKLqQQkRpMFqcIOJdZ+3eflrcY/T/5V2",
+			"host_rsa_public": "AAAAB3NzaC1yc2EAAAABIwAAAQEAuQVCJ1SLm/4FDi/wT5ZCVfdJ/id0aVKqRMU5fNX9ykJS6ZqOzwG2DVHREOmANn4A8aVu/r+dxWmm31m3Lh4GkZoC/sRbT2ng5OqDKVTqLwi6lotSdqQ/os4iDgHnzLylDpYS7gbvlbgM3HRXlQ9Uq1Fb+gzxUpEZUZVm98NvlffqvGFdV2B29WVl7v6oRR8nUOwabTiDktfTRbuLNkGZwLCl146u2QKJoJKtz03DabisVPpxAn+Ny3wFWScBmugTL0uN7XBnvPWwehfdWczTon/Yh6A/ieejwhN4xmxcTaS4B+L+h9VCWMZoBmTTFBazp4R9N6myCTewUguSl4IyDQ=="
+		}
+	},
+	"languages": {
+		"c": {
+			"glibc": {
+				"version": "2.12",
+				"description": "GNU C Library stable release version 2.12, by Roland McGrath et al."
+			}
+		},
+		"python": {
+			"version": "2.6.6",
+			"builddate": "Aug 18 2016, 15:13:37"
+		},
+		"lua": {
+			"version": "5.1.4"
+		},
+		"ruby": {}
+	},
+	"lsb": {},
+	"macaddress": "0A:AE:4E:50:46:FE",
+	"machinename": "ip-172-30-0-123",
+	"memory": {
+		"swap": {
+			"cached": "0kB",
+			"total": "0kB",
+			"free": "0kB"
+		},
+		"hugepages": {
+			"total": "0",
+			"free": "0",
+			"reserved": "0",
+			"surplus": "0"
+		},
+		"total": "1018092kB",
+		"free": "613804kB",
+		"buffers": "21180kB",
+		"cached": "239836kB",
+		"active": "94704kB",
+		"inactive": "194556kB",
+		"dirty": "340kB",
+		"writeback": "0kB",
+		"anon_pages": "28244kB",
+		"mapped": "10588kB",
+		"slab": "96872kB",
+		"slab_reclaimable": "41992kB",
+		"slab_unreclaim": "54880kB",
+		"page_tables": "1904kB",
+		"nfs_unstable": "0kB",
+		"bounce": "0kB",
+		"commit_limit": "509044kB",
+		"committed_as": "91296kB",
+		"vmalloc_total": "34359738367kB",
+		"vmalloc_used": "9548kB",
+		"vmalloc_chunk": "34359726716kB",
+		"hugepage_size": "2048kB"
+	},
+	"network": {
+		"interfaces": {
+			"lo": {
+				"mtu": "65536",
+				"flags": [
+					"LOOPBACK",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Loopback",
+				"addresses": {
+					"127.0.0.1": {
+						"family": "inet",
+						"prefixlen": "8",
+						"netmask": "255.0.0.0",
+						"scope": "Node"
+					},
+					"::1": {
+						"family": "inet6",
+						"prefixlen": "128",
+						"scope": "Node",
+						"tags": []
+					}
+				},
+				"state": "unknown",
+				"routes": [
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					}
+				]
+			},
+			"eth0": {
+				"type": "eth",
+				"number": "0",
+				"mtu": "9001",
+				"flags": [
+					"BROADCAST",
+					"MULTICAST",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Ethernet",
+				"addresses": {
+					"0A:AE:4E:50:46:FE": {
+						"family": "lladdr"
+					},
+					"172.30.0.123": {
+						"family": "inet",
+						"prefixlen": "24",
+						"netmask": "255.255.255.0",
+						"broadcast": "172.30.0.255",
+						"scope": "Global"
+					},
+					"fe80::8ae:4eff:fe50:46fe": {
+						"family": "inet6",
+						"prefixlen": "64",
+						"scope": "Link",
+						"tags": []
+					}
+				},
+				"state": "up",
+				"arp": {
+					"172.30.0.2": "0a:e7:37:d9:20:26",
+					"172.30.0.1": "0a:e7:37:d9:20:26"
+				},
+				"routes": [
+					{
+						"destination": "172.30.0.0/24",
+						"family": "inet",
+						"scope": "link",
+						"proto": "kernel",
+						"src": "172.30.0.123"
+					},
+					{
+						"destination": "default",
+						"family": "inet",
+						"via": "172.30.0.1"
+					},
+					{
+						"destination": "fe80::/64",
+						"family": "inet6",
+						"metric": "256",
+						"proto": "kernel"
+					}
+				],
+				"ring_params": {}
+			}
+		},
+		"default_interface": "eth0",
+		"default_gateway": "172.30.0.1"
+	},
+	"ohai_time": 1554008835.2345273,
+	"os": "linux",
+	"os_version": "2.6.32-754.10.1.el6.x86_64",
+	"packages": {
+		"setup": {
+			"epoch": "0",
+			"version": "2.8.14",
+			"release": "23.el6",
+			"installdate": "1548708518",
+			"arch": "noarch"
+		},
+		"basesystem": {
+			"epoch": "0",
+			"version": "10.0",
+			"release": "4.el6",
+			"installdate": "1548708519",
+			"arch": "noarch"
+		},
+		"tzdata": {
+			"epoch": "0",
+			"version": "2018i",
+			"release": "1.el6",
+			"installdate": "1548708520",
+			"arch": "noarch"
+		},
+		"nss-softokn-freebl": {
+			"epoch": "0",
+			"version": "3.14.3",
+			"release": "23.3.el6_8",
+			"installdate": "1548708527",
+			"arch": "x86_64"
+		},
+		"ncurses-libs": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"libattr": {
+			"epoch": "0",
+			"version": "2.4.44",
+			"release": "7.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"zlib": {
+			"epoch": "0",
+			"version": "1.2.3",
+			"release": "29.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"audit-libs": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"bzip2-libs": {
+			"epoch": "0",
+			"version": "1.0.5",
+			"release": "7.el6_0",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libcom_err": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"db4": {
+			"epoch": "0",
+			"version": "4.7.25",
+			"release": "22.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libselinux": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"sed": {
+			"epoch": "0",
+			"version": "4.2.1",
+			"release": "10.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"xz-libs": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"gawk": {
+			"epoch": "0",
+			"version": "3.1.7",
+			"release": "10.el6_7.3",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"sqlite": {
+			"epoch": "0",
+			"version": "3.6.20",
+			"release": "1.el6_7.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"file-libs": {
+			"epoch": "0",
+			"version": "5.04",
+			"release": "30.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"dbus-libs": {
+			"epoch": "1",
+			"version": "1.2.24",
+			"release": "9.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"pcre": {
+			"epoch": "0",
+			"version": "7.8",
+			"release": "7.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"findutils": {
+			"epoch": "1",
+			"version": "4.4.2",
+			"release": "9.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"bzip2": {
+			"epoch": "0",
+			"version": "1.0.5",
+			"release": "7.el6_0",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libuuid": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libgpg-error": {
+			"epoch": "0",
+			"version": "1.7",
+			"release": "4.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"procps": {
+			"epoch": "0",
+			"version": "3.2.8",
+			"release": "45.el6_9.3",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libselinux-utils": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"cpio": {
+			"epoch": "0",
+			"version": "2.10",
+			"release": "13.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"tcp_wrappers-libs": {
+			"epoch": "0",
+			"version": "7.6",
+			"release": "58.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"sysvinit-tools": {
+			"epoch": "0",
+			"version": "2.87",
+			"release": "6.dsf.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libudev": {
+			"epoch": "0",
+			"version": "147",
+			"release": "2.73.el6_8.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libtasn1": {
+			"epoch": "0",
+			"version": "2.3",
+			"release": "6.el6_5",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"p11-kit-trust": {
+			"epoch": "0",
+			"version": "0.18.5",
+			"release": "2.el6_5.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libnih": {
+			"epoch": "0",
+			"version": "1.0.1",
+			"release": "8.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"setools-libs": {
+			"epoch": "0",
+			"version": "3.3.7",
+			"release": "4.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"elfutils-libs": {
+			"epoch": "0",
+			"version": "0.164",
+			"release": "2.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"gmp": {
+			"epoch": "0",
+			"version": "4.3.1",
+			"release": "13.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"libusb": {
+			"epoch": "0",
+			"version": "0.1.12",
+			"release": "23.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"xz-lzma-compat": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"vim-minimal": {
+			"epoch": "2",
+			"version": "7.4.629",
+			"release": "5.el6_8.1",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"tar": {
+			"epoch": "2",
+			"version": "1.23",
+			"release": "15.el6_8",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"libss": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"e2fsprogs": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"which": {
+			"epoch": "0",
+			"version": "2.19",
+			"release": "6.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"m4": {
+			"epoch": "0",
+			"version": "1.4.13",
+			"release": "5.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"ncurses": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"less": {
+			"epoch": "0",
+			"version": "436",
+			"release": "13.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"gzip": {
+			"epoch": "0",
+			"version": "1.3.12",
+			"release": "24.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"cracklib-dicts": {
+			"epoch": "0",
+			"version": "2.8.16",
+			"release": "4.el6",
+			"installdate": "1548708535",
+			"arch": "x86_64"
+		},
+		"pam": {
+			"epoch": "0",
+			"version": "1.1.1",
+			"release": "24.el6",
+			"installdate": "1548708536",
+			"arch": "x86_64"
+		},
+		"hwdata": {
+			"epoch": "0",
+			"version": "0.233",
+			"release": "20.1.el6",
+			"installdate": "1548708536",
+			"arch": "noarch"
+		},
+		"redhat-logos": {
+			"epoch": "0",
+			"version": "60.0.14",
+			"release": "12.el6.centos",
+			"installdate": "1548708538",
+			"arch": "noarch"
+		},
+		"pciutils": {
+			"epoch": "0",
+			"version": "3.1.10",
+			"release": "4.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"logrotate": {
+			"epoch": "0",
+			"version": "3.7.8",
+			"release": "28.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss-sysinit": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libedit": {
+			"epoch": "0",
+			"version": "2.11",
+			"release": "4.20080712cvs.1.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libcap-ng": {
+			"epoch": "0",
+			"version": "0.6.4",
+			"release": "3.el6_0.1",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"mingetty": {
+			"epoch": "0",
+			"version": "1.08",
+			"release": "5.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libyaml": {
+			"epoch": "0",
+			"version": "0.1.3",
+			"release": "4.el6_6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"krb5-libs": {
+			"epoch": "0",
+			"version": "1.10.3",
+			"release": "65.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libssh2": {
+			"epoch": "0",
+			"version": "1.4.2",
+			"release": "2.el6_7.1",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"rpm-libs": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"rpm": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"gnupg2": {
+			"epoch": "0",
+			"version": "2.0.14",
+			"release": "9.el6_10",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"deltarpm": {
+			"epoch": "0",
+			"version": "3.5",
+			"release": "0.5.20090913git.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"fipscheck-lib": {
+			"epoch": "0",
+			"version": "1.2.0",
+			"release": "7.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"ustr": {
+			"epoch": "0",
+			"version": "1.0.4",
+			"release": "9.1.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"shadow-utils": {
+			"epoch": "2",
+			"version": "4.1.5.1",
+			"release": "5.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"MAKEDEV": {
+			"epoch": "0",
+			"version": "3.24",
+			"release": "6.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"newt": {
+			"epoch": "0",
+			"version": "0.52.11",
+			"release": "4.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"gdbm": {
+			"epoch": "0",
+			"version": "1.8.0",
+			"release": "39.el6",
+			"installdate": "1548708544",
+			"arch": "x86_64"
+		},
+		"python": {
+			"epoch": "0",
+			"version": "2.6.6",
+			"release": "66.el6_8",
+			"installdate": "1548708545",
+			"arch": "x86_64"
+		},
+		"libselinux-python": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"rpm-python": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"libsemanage-python": {
+			"epoch": "0",
+			"version": "2.0.43",
+			"release": "5.1.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"m2crypto": {
+			"epoch": "0",
+			"version": "0.20.2",
+			"release": "9.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-urlgrabber": {
+			"epoch": "0",
+			"version": "3.9.1",
+			"release": "11.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-prettytable": {
+			"epoch": "0",
+			"version": "0.7.2",
+			"release": "11.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-configobj": {
+			"epoch": "0",
+			"version": "4.6.0",
+			"release": "3.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-iniparse": {
+			"epoch": "0",
+			"version": "0.3.1",
+			"release": "2.1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-markdown": {
+			"epoch": "0",
+			"version": "2.0.1",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-jsonpatch": {
+			"epoch": "0",
+			"version": "1.2",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-setuptools": {
+			"epoch": "0",
+			"version": "0.6.10",
+			"release": "4.el6_9",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-cheetah": {
+			"epoch": "0",
+			"version": "2.4.1",
+			"release": "1.el6",
+			"installdate": "1548708550",
+			"arch": "x86_64"
+		},
+		"python-backports": {
+			"epoch": "0",
+			"version": "1.0",
+			"release": "5.el6",
+			"installdate": "1548708550",
+			"arch": "x86_64"
+		},
+		"python-urllib3": {
+			"epoch": "0",
+			"version": "1.10.2",
+			"release": "3.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-boto": {
+			"epoch": "1",
+			"version": "2.34.0",
+			"release": "6.el6",
+			"installdate": "1548708552",
+			"arch": "noarch"
+		},
+		"gamin": {
+			"epoch": "0",
+			"version": "0.1.10",
+			"release": "9.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"shared-mime-info": {
+			"epoch": "0",
+			"version": "0.70",
+			"release": "6.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"libuser": {
+			"epoch": "0",
+			"version": "0.56.13",
+			"release": "8.el6_7",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum-metadata-parser": {
+			"epoch": "0",
+			"version": "1.1.2",
+			"release": "16.el6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum": {
+			"epoch": "0",
+			"version": "3.2.29",
+			"release": "81.el6.centos.0.1",
+			"installdate": "1548708553",
+			"arch": "noarch"
+		},
+		"kernel-firmware": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "754.10.1.el6",
+			"installdate": "1548708557",
+			"arch": "noarch"
+		},
+		"centos-release": {
+			"epoch": "0",
+			"version": "6",
+			"release": "10.el6.centos.12.3",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iptables": {
+			"epoch": "0",
+			"version": "1.4.7",
+			"release": "19.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"libdrm": {
+			"epoch": "0",
+			"version": "2.4.65",
+			"release": "2.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iputils": {
+			"epoch": "0",
+			"version": "20071127",
+			"release": "24.el6",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"initscripts": {
+			"epoch": "0",
+			"version": "9.03.61",
+			"release": "1.el6.centos",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"rsyslog": {
+			"epoch": "0",
+			"version": "5.8.10",
+			"release": "12.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"mdadm": {
+			"epoch": "0",
+			"version": "3.3.4",
+			"release": "8.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"device-mapper": {
+			"epoch": "0",
+			"version": "1.02.117",
+			"release": "12.el6_9.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"kbd": {
+			"epoch": "0",
+			"version": "1.15",
+			"release": "11.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"dracut-kernel": {
+			"epoch": "0",
+			"version": "004",
+			"release": "411.el6",
+			"installdate": "1548708561",
+			"arch": "noarch"
+		},
+		"postfix": {
+			"epoch": "2",
+			"version": "2.6.6",
+			"release": "8.el6",
+			"installdate": "1548708562",
+			"arch": "x86_64"
+		},
+		"cronie-anacron": {
+			"epoch": "0",
+			"version": "1.4.4",
+			"release": "16.el6_8.2",
+			"installdate": "1548708563",
+			"arch": "x86_64"
+		},
+		"libcgroup": {
+			"epoch": "0",
+			"version": "0.40.rc1",
+			"release": "27.el6_10",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"iptables-ipv6": {
+			"epoch": "0",
+			"version": "1.4.7",
+			"release": "19.el6",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"selinux-policy": {
+			"epoch": "0",
+			"version": "3.7.19",
+			"release": "312.el6",
+			"installdate": "1548708568",
+			"arch": "noarch"
+		},
+		"dhclient": {
+			"epoch": "12",
+			"version": "4.1.1",
+			"release": "63.P1.el6.centos",
+			"installdate": "1548708568",
+			"arch": "x86_64"
+		},
+		"system-config-firewall-tui": {
+			"epoch": "0",
+			"version": "1.2.27",
+			"release": "7.2.el6_6",
+			"installdate": "1548708595",
+			"arch": "noarch"
+		},
+		"kernel": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "754.10.1.el6",
+			"installdate": "1548708605",
+			"arch": "x86_64"
+		},
+		"kexec-tools": {
+			"epoch": "0",
+			"version": "2.0.0",
+			"release": "310.el6",
+			"installdate": "1548708606",
+			"arch": "x86_64"
+		},
+		"openssh-server": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"acpid": {
+			"epoch": "0",
+			"version": "1.0.10",
+			"release": "3.el6",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"passwd": {
+			"epoch": "0",
+			"version": "0.77",
+			"release": "7.el6",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"sudo": {
+			"epoch": "0",
+			"version": "1.8.6p3",
+			"release": "29.el6_9",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"audit": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"rsync": {
+			"epoch": "0",
+			"version": "3.0.6",
+			"release": "12.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"attr": {
+			"epoch": "0",
+			"version": "2.4.44",
+			"release": "7.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"chef": {
+			"epoch": "0",
+			"version": "14.11.21",
+			"release": "1.el6",
+			"installdate": "1554008708",
+			"arch": "x86_64"
+		},
+		"libgcc": {
+			"epoch": "0",
+			"version": "4.4.7",
+			"release": "23.el6",
+			"installdate": "1548708518",
+			"arch": "x86_64"
+		},
+		"filesystem": {
+			"epoch": "0",
+			"version": "2.4.30",
+			"release": "3.el6",
+			"installdate": "1548708518",
+			"arch": "x86_64"
+		},
+		"ncurses-base": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708519",
+			"arch": "x86_64"
+		},
+		"glibc-common": {
+			"epoch": "0",
+			"version": "2.12",
+			"release": "1.212.el6",
+			"installdate": "1548708525",
+			"arch": "x86_64"
+		},
+		"glibc": {
+			"epoch": "0",
+			"version": "2.12",
+			"release": "1.212.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"bash": {
+			"epoch": "0",
+			"version": "4.1.2",
+			"release": "48.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"libcap": {
+			"epoch": "0",
+			"version": "2.16",
+			"release": "5.5.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"info": {
+			"epoch": "0",
+			"version": "4.13a",
+			"release": "8.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"popt": {
+			"epoch": "0",
+			"version": "1.13",
+			"release": "7.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libacl": {
+			"epoch": "0",
+			"version": "2.2.49",
+			"release": "7.el6_9.1",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"nspr": {
+			"epoch": "0",
+			"version": "4.19.0",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libsepol": {
+			"epoch": "0",
+			"version": "2.0.41",
+			"release": "4.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"chkconfig": {
+			"epoch": "0",
+			"version": "1.3.49.5",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"nss-util": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libstdc++": {
+			"epoch": "0",
+			"version": "4.4.7",
+			"release": "23.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"readline": {
+			"epoch": "0",
+			"version": "6.0",
+			"release": "4.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"elfutils-libelf": {
+			"epoch": "0",
+			"version": "0.164",
+			"release": "2.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libxml2": {
+			"epoch": "0",
+			"version": "2.7.6",
+			"release": "21.el6_8.1",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"lua": {
+			"epoch": "0",
+			"version": "5.1.4",
+			"release": "4.1.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"grep": {
+			"epoch": "0",
+			"version": "2.20",
+			"release": "6.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"cyrus-sasl-lib": {
+			"epoch": "0",
+			"version": "2.1.23",
+			"release": "15.el6_6.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libidn": {
+			"epoch": "0",
+			"version": "1.18",
+			"release": "2.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libblkid": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"nss-softokn": {
+			"epoch": "0",
+			"version": "3.14.3",
+			"release": "23.3.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"net-tools": {
+			"epoch": "0",
+			"version": "1.60",
+			"release": "114.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"checkpolicy": {
+			"epoch": "0",
+			"version": "2.0.22",
+			"release": "1.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"make": {
+			"epoch": "1",
+			"version": "3.81",
+			"release": "23.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"pciutils-libs": {
+			"epoch": "0",
+			"version": "3.1.10",
+			"release": "4.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"expat": {
+			"epoch": "0",
+			"version": "2.0.1",
+			"release": "13.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"pth": {
+			"epoch": "0",
+			"version": "2.0.7",
+			"release": "9.3.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"p11-kit": {
+			"epoch": "0",
+			"version": "0.18.5",
+			"release": "2.el6_5.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libgcrypt": {
+			"epoch": "0",
+			"version": "1.4.5",
+			"release": "12.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"upstart": {
+			"epoch": "0",
+			"version": "0.6.5",
+			"release": "17.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"file": {
+			"epoch": "0",
+			"version": "5.04",
+			"release": "30.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"bc": {
+			"epoch": "0",
+			"version": "1.06.95",
+			"release": "1.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"snappy": {
+			"epoch": "0",
+			"version": "1.1.0",
+			"release": "1.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"xz": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"pinentry": {
+			"epoch": "0",
+			"version": "0.7.6",
+			"release": "8.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"psmisc": {
+			"epoch": "0",
+			"version": "22.6",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"db4-utils": {
+			"epoch": "0",
+			"version": "4.7.25",
+			"release": "22.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"e2fsprogs-libs": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"diffutils": {
+			"epoch": "0",
+			"version": "2.8.1",
+			"release": "28.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"binutils": {
+			"epoch": "0",
+			"version": "2.20.51.0.2",
+			"release": "5.48.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"dash": {
+			"epoch": "0",
+			"version": "0.5.5.1",
+			"release": "4.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"groff": {
+			"epoch": "0",
+			"version": "1.18.1.4",
+			"release": "21.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"coreutils-libs": {
+			"epoch": "0",
+			"version": "8.4",
+			"release": "47.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"cracklib": {
+			"epoch": "0",
+			"version": "2.8.16",
+			"release": "4.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"coreutils": {
+			"epoch": "0",
+			"version": "8.4",
+			"release": "47.el6",
+			"installdate": "1548708535",
+			"arch": "x86_64"
+		},
+		"module-init-tools": {
+			"epoch": "0",
+			"version": "3.9",
+			"release": "26.el6",
+			"installdate": "1548708536",
+			"arch": "x86_64"
+		},
+		"ca-certificates": {
+			"epoch": "0",
+			"version": "2018.2.22",
+			"release": "65.1.el6",
+			"installdate": "1548708536",
+			"arch": "noarch"
+		},
+		"plymouth-scripts": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libpciaccess": {
+			"epoch": "0",
+			"version": "0.13.4",
+			"release": "1.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss-tools": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"dmidecode": {
+			"epoch": "1",
+			"version": "2.12",
+			"release": "7.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"ethtool": {
+			"epoch": "2",
+			"version": "3.5",
+			"release": "6.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"lzo": {
+			"epoch": "0",
+			"version": "2.03",
+			"release": "3.1.el6_5.1",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"keyutils-libs": {
+			"epoch": "0",
+			"version": "1.4",
+			"release": "5.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"openssl": {
+			"epoch": "0",
+			"version": "1.0.1e",
+			"release": "57.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libcurl": {
+			"epoch": "0",
+			"version": "7.19.7",
+			"release": "53.el6_9",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"curl": {
+			"epoch": "0",
+			"version": "7.19.7",
+			"release": "53.el6_9",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"openldap": {
+			"epoch": "0",
+			"version": "2.4.40",
+			"release": "16.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"gpgme": {
+			"epoch": "0",
+			"version": "1.1.8",
+			"release": "3.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"mysql-libs": {
+			"epoch": "0",
+			"version": "5.1.73",
+			"release": "8.el6_8",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"fipscheck": {
+			"epoch": "0",
+			"version": "1.2.0",
+			"release": "7.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"libsemanage": {
+			"epoch": "0",
+			"version": "2.0.43",
+			"release": "5.1.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"libutempter": {
+			"epoch": "0",
+			"version": "1.1.5",
+			"release": "4.1.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"slang": {
+			"epoch": "0",
+			"version": "2.2.1",
+			"release": "1.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"plymouth-core-libs": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708543",
+			"arch": "x86_64"
+		},
+		"libffi": {
+			"epoch": "0",
+			"version": "3.0.5",
+			"release": "3.2.el6",
+			"installdate": "1548708545",
+			"arch": "x86_64"
+		},
+		"python-libs": {
+			"epoch": "0",
+			"version": "2.6.6",
+			"release": "66.el6_8",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"PyYAML": {
+			"epoch": "0",
+			"version": "3.10",
+			"release": "3.1.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"pygpgme": {
+			"epoch": "0",
+			"version": "0.1",
+			"release": "18.20090824bzr68.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"setools-libs-python": {
+			"epoch": "0",
+			"version": "3.3.7",
+			"release": "4.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"python-pycurl": {
+			"epoch": "0",
+			"version": "7.19.0",
+			"release": "9.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"newt-python": {
+			"epoch": "0",
+			"version": "0.52.11",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-oauth": {
+			"epoch": "0",
+			"version": "1.0.1",
+			"release": "1.el6.centos",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-argparse": {
+			"epoch": "0",
+			"version": "1.2.1",
+			"release": "2.1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"audit-libs-python": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-jsonpointer": {
+			"epoch": "0",
+			"version": "1.0",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-chardet": {
+			"epoch": "0",
+			"version": "2.2.1",
+			"release": "1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-pygments": {
+			"epoch": "0",
+			"version": "1.1.1",
+			"release": "2.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-six": {
+			"epoch": "0",
+			"version": "1.9.0",
+			"release": "2.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-backports-ssl_match_hostname": {
+			"epoch": "0",
+			"version": "3.4.0.2",
+			"release": "5.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-requests": {
+			"epoch": "0",
+			"version": "2.6.0",
+			"release": "4.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"pkgconfig": {
+			"epoch": "1",
+			"version": "0.23",
+			"release": "9.1.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"glib2": {
+			"epoch": "0",
+			"version": "2.28.8",
+			"release": "10.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"grubby": {
+			"epoch": "0",
+			"version": "7.0.15",
+			"release": "7.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"dbus-glib": {
+			"epoch": "0",
+			"version": "0.86",
+			"release": "6.el6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum-plugin-fastestmirror": {
+			"epoch": "0",
+			"version": "1.1.30",
+			"release": "42.el6_10",
+			"installdate": "1548708553",
+			"arch": "noarch"
+		},
+		"busybox": {
+			"epoch": "1",
+			"version": "1.15.1",
+			"release": "21.el6_6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"kbd-misc": {
+			"epoch": "0",
+			"version": "1.15",
+			"release": "11.el6",
+			"installdate": "1548708558",
+			"arch": "noarch"
+		},
+		"policycoreutils": {
+			"epoch": "0",
+			"version": "2.0.83",
+			"release": "30.1.el6_8",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iproute": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "57.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"plymouth": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"util-linux-ng": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"udev": {
+			"epoch": "0",
+			"version": "147",
+			"release": "2.73.el6_8.2",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"openssh": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"device-mapper-libs": {
+			"epoch": "0",
+			"version": "1.02.117",
+			"release": "12.el6_9.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"kpartx": {
+			"epoch": "0",
+			"version": "0.4.9",
+			"release": "106.el6_10.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"dracut": {
+			"epoch": "0",
+			"version": "004",
+			"release": "411.el6",
+			"installdate": "1548708561",
+			"arch": "noarch"
+		},
+		"cyrus-sasl": {
+			"epoch": "0",
+			"version": "2.1.23",
+			"release": "15.el6_6.2",
+			"installdate": "1548708561",
+			"arch": "x86_64"
+		},
+		"crontabs": {
+			"epoch": "0",
+			"version": "1.10",
+			"release": "33.el6",
+			"installdate": "1548708563",
+			"arch": "noarch"
+		},
+		"cronie": {
+			"epoch": "0",
+			"version": "1.4.4",
+			"release": "16.el6_8.2",
+			"installdate": "1548708563",
+			"arch": "x86_64"
+		},
+		"policycoreutils-python": {
+			"epoch": "0",
+			"version": "2.0.83",
+			"release": "30.1.el6_8",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"system-config-firewall-base": {
+			"epoch": "0",
+			"version": "1.2.27",
+			"release": "7.2.el6_6",
+			"installdate": "1548708567",
+			"arch": "noarch"
+		},
+		"dhcp-common": {
+			"epoch": "12",
+			"version": "4.1.1",
+			"release": "63.P1.el6.centos",
+			"installdate": "1548708568",
+			"arch": "x86_64"
+		},
+		"selinux-policy-targeted": {
+			"epoch": "0",
+			"version": "3.7.19",
+			"release": "312.el6",
+			"installdate": "1548708569",
+			"arch": "noarch"
+		},
+		"cloud-init": {
+			"epoch": "0",
+			"version": "0.7.5",
+			"release": "10.el6.centos.2",
+			"installdate": "1548708596",
+			"arch": "x86_64"
+		},
+		"rdma": {
+			"epoch": "0",
+			"version": "6.9_4.1",
+			"release": "3.el6",
+			"installdate": "1548708606",
+			"arch": "noarch"
+		},
+		"openssh-clients": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"b43-openfwwf": {
+			"epoch": "0",
+			"version": "5.2",
+			"release": "10.el6",
+			"installdate": "1548708607",
+			"arch": "noarch"
+		},
+		"yum-presto": {
+			"epoch": "0",
+			"version": "0.6.2",
+			"release": "1.el6",
+			"installdate": "1548708607",
+			"arch": "noarch"
+		},
+		"grub": {
+			"epoch": "1",
+			"version": "0.97",
+			"release": "99.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"man": {
+			"epoch": "0",
+			"version": "1.6f",
+			"release": "39.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"efibootmgr": {
+			"epoch": "0",
+			"version": "0.5.4",
+			"release": "15.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"acl": {
+			"epoch": "0",
+			"version": "2.2.49",
+			"release": "7.el6_9.1",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"rootfiles": {
+			"epoch": "0",
+			"version": "8.1",
+			"release": "6.1.el6",
+			"installdate": "1548708608",
+			"arch": "noarch"
+		}
+	},
+	"platform": "centos",
+	"platform_family": "rhel",
+	"platform_version": "6.10",
+	"root_group": "root",
+	"shard_seed": 172911308,
+	"shells": [
+		"/bin/sh",
+		"/bin/bash",
+		"/sbin/nologin",
+		"/bin/dash"
+	],
+	"sysconf": {
+		"LINK_MAX": 32000,
+		"_POSIX_LINK_MAX": 32000,
+		"MAX_CANON": 255,
+		"_POSIX_MAX_CANON": 255,
+		"MAX_INPUT": 255,
+		"_POSIX_MAX_INPUT": 255,
+		"NAME_MAX": 255,
+		"_POSIX_NAME_MAX": 255,
+		"PATH_MAX": 4096,
+		"_POSIX_PATH_MAX": 4096,
+		"PIPE_BUF": 4096,
+		"_POSIX_PIPE_BUF": 4096,
+		"SOCK_MAXBUF": null,
+		"_POSIX_ASYNC_IO": null,
+		"_POSIX_CHOWN_RESTRICTED": 1,
+		"_POSIX_NO_TRUNC": 1,
+		"_POSIX_PRIO_IO": null,
+		"_POSIX_SYNC_IO": null,
+		"_POSIX_VDISABLE": 0,
+		"ARG_MAX": 2621440,
+		"ATEXIT_MAX": 2147483647,
+		"CHAR_BIT": 8,
+		"CHAR_MAX": 127,
+		"CHAR_MIN": -128,
+		"CHILD_MAX": 1024,
+		"CLK_TCK": 100,
+		"INT_MAX": 2147483647,
+		"INT_MIN": -2147483648,
+		"IOV_MAX": 1024,
+		"LOGNAME_MAX": 256,
+		"LONG_BIT": 64,
+		"MB_LEN_MAX": 16,
+		"NGROUPS_MAX": 65536,
+		"NL_ARGMAX": 4096,
+		"NL_LANGMAX": 2048,
+		"NL_MSGMAX": 2147483647,
+		"NL_NMAX": 2147483647,
+		"NL_SETMAX": 2147483647,
+		"NL_TEXTMAX": 2147483647,
+		"NSS_BUFLEN_GROUP": 1024,
+		"NSS_BUFLEN_PASSWD": 1024,
+		"NZERO": 20,
+		"OPEN_MAX": 1024,
+		"PAGESIZE": 4096,
+		"PAGE_SIZE": 4096,
+		"PASS_MAX": 8192,
+		"PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+		"PTHREAD_KEYS_MAX": 1024,
+		"PTHREAD_STACK_MIN": 16384,
+		"PTHREAD_THREADS_MAX": null,
+		"SCHAR_MAX": 127,
+		"SCHAR_MIN": -128,
+		"SHRT_MAX": 32767,
+		"SHRT_MIN": -32768,
+		"SSIZE_MAX": 32767,
+		"TTY_NAME_MAX": 32,
+		"TZNAME_MAX": 6,
+		"UCHAR_MAX": 255,
+		"UINT_MAX": 4294967295,
+		"UIO_MAXIOV": 1024,
+		"ULONG_MAX": 18446744073709552000,
+		"USHRT_MAX": 65535,
+		"WORD_BIT": 32,
+		"_AVPHYS_PAGES": 152679,
+		"_NPROCESSORS_CONF": 1,
+		"_NPROCESSORS_ONLN": 1,
+		"_PHYS_PAGES": 254523,
+		"_POSIX_ARG_MAX": 2621440,
+		"_POSIX_ASYNCHRONOUS_IO": 200809,
+		"_POSIX_CHILD_MAX": 1024,
+		"_POSIX_FSYNC": 200809,
+		"_POSIX_JOB_CONTROL": 1,
+		"_POSIX_MAPPED_FILES": 200809,
+		"_POSIX_MEMLOCK": 200809,
+		"_POSIX_MEMLOCK_RANGE": 200809,
+		"_POSIX_MEMORY_PROTECTION": 200809,
+		"_POSIX_MESSAGE_PASSING": 200809,
+		"_POSIX_NGROUPS_MAX": 65536,
+		"_POSIX_OPEN_MAX": 1024,
+		"_POSIX_PII": null,
+		"_POSIX_PII_INTERNET": null,
+		"_POSIX_PII_INTERNET_DGRAM": null,
+		"_POSIX_PII_INTERNET_STREAM": null,
+		"_POSIX_PII_OSI": null,
+		"_POSIX_PII_OSI_CLTS": null,
+		"_POSIX_PII_OSI_COTS": null,
+		"_POSIX_PII_OSI_M": null,
+		"_POSIX_PII_SOCKET": null,
+		"_POSIX_PII_XTI": null,
+		"_POSIX_POLL": null,
+		"_POSIX_PRIORITIZED_IO": 200809,
+		"_POSIX_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_REALTIME_SIGNALS": 200809,
+		"_POSIX_SAVED_IDS": 1,
+		"_POSIX_SELECT": null,
+		"_POSIX_SEMAPHORES": 200809,
+		"_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+		"_POSIX_SSIZE_MAX": 32767,
+		"_POSIX_STREAM_MAX": 16,
+		"_POSIX_SYNCHRONIZED_IO": 200809,
+		"_POSIX_THREADS": 200809,
+		"_POSIX_THREAD_ATTR_STACKADDR": 200809,
+		"_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+		"_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_THREAD_PRIO_INHERIT": 200809,
+		"_POSIX_THREAD_PRIO_PROTECT": 200809,
+		"_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+		"_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+		"_POSIX_THREAD_PROCESS_SHARED": 200809,
+		"_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+		"_POSIX_TIMERS": 200809,
+		"TIMER_MAX": null,
+		"_POSIX_TZNAME_MAX": 6,
+		"_POSIX_VERSION": 200809,
+		"_T_IOV_MAX": null,
+		"_XOPEN_CRYPT": 1,
+		"_XOPEN_ENH_I18N": 1,
+		"_XOPEN_LEGACY": 1,
+		"_XOPEN_REALTIME": 1,
+		"_XOPEN_REALTIME_THREADS": 1,
+		"_XOPEN_SHM": 1,
+		"_XOPEN_UNIX": 1,
+		"_XOPEN_VERSION": 700,
+		"_XOPEN_XCU_VERSION": 4,
+		"_XOPEN_XPG2": 1,
+		"_XOPEN_XPG3": 1,
+		"_XOPEN_XPG4": 1,
+		"BC_BASE_MAX": 99,
+		"BC_DIM_MAX": 2048,
+		"BC_SCALE_MAX": 99,
+		"BC_STRING_MAX": 1000,
+		"CHARCLASS_NAME_MAX": 2048,
+		"COLL_WEIGHTS_MAX": 255,
+		"EQUIV_CLASS_MAX": null,
+		"EXPR_NEST_MAX": 32,
+		"LINE_MAX": 2048,
+		"POSIX2_BC_BASE_MAX": 99,
+		"POSIX2_BC_DIM_MAX": 2048,
+		"POSIX2_BC_SCALE_MAX": 99,
+		"POSIX2_BC_STRING_MAX": 1000,
+		"POSIX2_CHAR_TERM": 200809,
+		"POSIX2_COLL_WEIGHTS_MAX": 255,
+		"POSIX2_C_BIND": 200809,
+		"POSIX2_C_DEV": 200809,
+		"POSIX2_C_VERSION": null,
+		"POSIX2_EXPR_NEST_MAX": 32,
+		"POSIX2_FORT_DEV": null,
+		"POSIX2_FORT_RUN": null,
+		"_POSIX2_LINE_MAX": 2048,
+		"POSIX2_LINE_MAX": 2048,
+		"POSIX2_LOCALEDEF": 200809,
+		"POSIX2_RE_DUP_MAX": 32767,
+		"POSIX2_SW_DEV": 200809,
+		"POSIX2_UPE": null,
+		"POSIX2_VERSION": 200809,
+		"RE_DUP_MAX": 32767,
+		"PATH": "/bin:/usr/bin",
+		"CS_PATH": "/bin:/usr/bin",
+		"LFS_CFLAGS": null,
+		"LFS_LDFLAGS": null,
+		"LFS_LIBS": null,
+		"LFS_LINTFLAGS": null,
+		"LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+		"LFS64_LDFLAGS": null,
+		"LFS64_LIBS": null,
+		"LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+		"_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"_XBS5_ILP32_OFF32": null,
+		"XBS5_ILP32_OFF32_CFLAGS": null,
+		"XBS5_ILP32_OFF32_LDFLAGS": null,
+		"XBS5_ILP32_OFF32_LIBS": null,
+		"XBS5_ILP32_OFF32_LINTFLAGS": null,
+		"_XBS5_ILP32_OFFBIG": null,
+		"XBS5_ILP32_OFFBIG_CFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LDFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LIBS": null,
+		"XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+		"_XBS5_LP64_OFF64": 1,
+		"XBS5_LP64_OFF64_CFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LDFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LIBS": null,
+		"XBS5_LP64_OFF64_LINTFLAGS": null,
+		"_XBS5_LPBIG_OFFBIG": null,
+		"XBS5_LPBIG_OFFBIG_CFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LIBS": null,
+		"XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_ILP32_OFF32": null,
+		"POSIX_V6_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LIBS": null,
+		"POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"_POSIX_V6_ILP32_OFFBIG": null,
+		"POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_LP64_OFF64": 1,
+		"POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LIBS": null,
+		"POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V6_LPBIG_OFFBIG": null,
+		"POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_ILP32_OFF32": null,
+		"POSIX_V7_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LIBS": null,
+		"POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"_POSIX_V7_ILP32_OFFBIG": null,
+		"POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_LP64_OFF64": 1,
+		"POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LIBS": null,
+		"POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V7_LPBIG_OFFBIG": null,
+		"POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_ADVISORY_INFO": 200809,
+		"_POSIX_BARRIERS": 200809,
+		"_POSIX_BASE": null,
+		"_POSIX_C_LANG_SUPPORT": null,
+		"_POSIX_C_LANG_SUPPORT_R": null,
+		"_POSIX_CLOCK_SELECTION": 200809,
+		"_POSIX_CPUTIME": 200809,
+		"_POSIX_THREAD_CPUTIME": 200809,
+		"_POSIX_DEVICE_SPECIFIC": null,
+		"_POSIX_DEVICE_SPECIFIC_R": null,
+		"_POSIX_FD_MGMT": null,
+		"_POSIX_FIFO": null,
+		"_POSIX_PIPE": null,
+		"_POSIX_FILE_ATTRIBUTES": null,
+		"_POSIX_FILE_LOCKING": null,
+		"_POSIX_FILE_SYSTEM": null,
+		"_POSIX_MONOTONIC_CLOCK": 200809,
+		"_POSIX_MULTI_PROCESS": null,
+		"_POSIX_SINGLE_PROCESS": null,
+		"_POSIX_NETWORKING": null,
+		"_POSIX_READER_WRITER_LOCKS": 200809,
+		"_POSIX_SPIN_LOCKS": 200809,
+		"_POSIX_REGEXP": 1,
+		"_REGEX_VERSION": null,
+		"_POSIX_SHELL": 1,
+		"_POSIX_SIGNALS": null,
+		"_POSIX_SPAWN": 200809,
+		"_POSIX_SPORADIC_SERVER": null,
+		"_POSIX_THREAD_SPORADIC_SERVER": null,
+		"_POSIX_SYSTEM_DATABASE": null,
+		"_POSIX_SYSTEM_DATABASE_R": null,
+		"_POSIX_TIMEOUTS": 200809,
+		"_POSIX_TYPED_MEMORY_OBJECTS": null,
+		"_POSIX_USER_GROUPS": null,
+		"_POSIX_USER_GROUPS_R": null,
+		"POSIX2_PBS": null,
+		"POSIX2_PBS_ACCOUNTING": null,
+		"POSIX2_PBS_LOCATE": null,
+		"POSIX2_PBS_TRACK": null,
+		"POSIX2_PBS_MESSAGE": null,
+		"SYMLOOP_MAX": null,
+		"STREAM_MAX": 16,
+		"AIO_LISTIO_MAX": null,
+		"AIO_MAX": null,
+		"AIO_PRIO_DELTA_MAX": 20,
+		"DELAYTIMER_MAX": 2147483647,
+		"HOST_NAME_MAX": 64,
+		"LOGIN_NAME_MAX": 256,
+		"MQ_OPEN_MAX": null,
+		"MQ_PRIO_MAX": 32768,
+		"_POSIX_DEVICE_IO": null,
+		"_POSIX_TRACE": null,
+		"_POSIX_TRACE_EVENT_FILTER": null,
+		"_POSIX_TRACE_INHERIT": null,
+		"_POSIX_TRACE_LOG": null,
+		"RTSIG_MAX": 32,
+		"SEM_NSEMS_MAX": null,
+		"SEM_VALUE_MAX": 2147483647,
+		"SIGQUEUE_MAX": 3892,
+		"FILESIZEBITS": 64,
+		"POSIX_ALLOC_SIZE_MIN": 4096,
+		"POSIX_REC_INCR_XFER_SIZE": null,
+		"POSIX_REC_MAX_XFER_SIZE": null,
+		"POSIX_REC_MIN_XFER_SIZE": 4096,
+		"POSIX_REC_XFER_ALIGN": 4096,
+		"SYMLINK_MAX": null,
+		"GNU_LIBC_VERSION": "glibc 2.12",
+		"GNU_LIBPTHREAD_VERSION": "NPTL 2.12",
+		"POSIX2_SYMLINKS": 1,
+		"LEVEL1_ICACHE_SIZE": 32768,
+		"LEVEL1_ICACHE_ASSOC": 8,
+		"LEVEL1_ICACHE_LINESIZE": 64,
+		"LEVEL1_DCACHE_SIZE": 32768,
+		"LEVEL1_DCACHE_ASSOC": 8,
+		"LEVEL1_DCACHE_LINESIZE": 64,
+		"LEVEL2_CACHE_SIZE": 262144,
+		"LEVEL2_CACHE_ASSOC": 8,
+		"LEVEL2_CACHE_LINESIZE": 64,
+		"LEVEL3_CACHE_SIZE": 31457280,
+		"LEVEL3_CACHE_ASSOC": 20,
+		"LEVEL3_CACHE_LINESIZE": 64,
+		"LEVEL4_CACHE_SIZE": 0,
+		"LEVEL4_CACHE_ASSOC": 0,
+		"LEVEL4_CACHE_LINESIZE": 0,
+		"IPV6": 200809,
+		"RAW_SOCKETS": 200809
+	},
+	"time": {
+		"timezone": "UTC"
+	},
+	"uptime": "32 minutes 25 seconds",
+	"uptime_seconds": 1945,
+	"virtualization": {
+		"systems": {
+			"xen": "guest"
+		},
+		"system": "xen",
+		"role": "guest"
+	}
+}

--- a/scans/centos-ec2-train.json
+++ b/scans/centos-ec2-train.json
@@ -1,0 +1,3407 @@
+{
+	"block_device": {
+		"loop0": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop1": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop2": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop3": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop4": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop5": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop6": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop7": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram0": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram1": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram10": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram11": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram12": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram13": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram14": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram15": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram2": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram3": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram4": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram5": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram6": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram7": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram8": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram9": {
+			"size": "32768",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"xvda": {
+			"size": "16777216",
+			"removable": "0",
+			"rotational": "0",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		}
+	},
+	"chef_packages": {
+		"ohai": {
+			"version": "15.0.30",
+			"ohai_root": "/Users/franklinwebber/src/ohai/lib/ohai"
+		}
+	},
+	"cloud": {
+		"public_ipv4_addrs": [
+			"54.167.86.159"
+		],
+		"local_ipv4_addrs": [
+			"172.30.0.100"
+		],
+		"provider": "ec2",
+		"public_hostname": "",
+		"local_hostname": "ip-172-30-0-100.ec2.internal",
+		"public_ipv4": "54.167.86.159",
+		"local_ipv4": "172.30.0.100"
+	},
+	"command": {
+		"ps": "ps -ef"
+	},
+	"counters": {
+		"network": {
+			"interfaces": {
+				"lo": {
+					"rx": {
+						"bytes": "0",
+						"packets": "0",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					},
+					"tx": {
+						"bytes": "0",
+						"packets": "0",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					}
+				},
+				"eth0": {
+					"tx": {
+						"queuelen": "1000",
+						"bytes": "40024642",
+						"packets": "205387",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "21457373",
+						"packets": "214567",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				}
+			}
+		}
+	},
+	"cpu": {
+		"0": {
+			"vendor_id": "GenuineIntel",
+			"family": "6",
+			"model": "63",
+			"model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+			"stepping": "2",
+			"mhz": "2400.034",
+			"cache_size": "30720 KB",
+			"physical_id": "0",
+			"core_id": "0",
+			"cores": "1",
+			"flags": [
+				"fpu",
+				"vme",
+				"de",
+				"pse",
+				"tsc",
+				"msr",
+				"pae",
+				"mce",
+				"cx8",
+				"apic",
+				"sep",
+				"mtrr",
+				"pge",
+				"mca",
+				"cmov",
+				"pat",
+				"pse36",
+				"clflush",
+				"mmx",
+				"fxsr",
+				"sse",
+				"sse2",
+				"ht",
+				"syscall",
+				"nx",
+				"rdtscp",
+				"lm",
+				"constant_tsc",
+				"up",
+				"rep_good",
+				"xtopology",
+				"unfair_spinlock",
+				"eagerfpu",
+				"pni",
+				"pclmulqdq",
+				"ssse3",
+				"fma",
+				"cx16",
+				"pcid",
+				"sse4_1",
+				"sse4_2",
+				"x2apic",
+				"movbe",
+				"popcnt",
+				"tsc_deadline_timer",
+				"aes",
+				"xsave",
+				"avx",
+				"f16c",
+				"rdrand",
+				"hypervisor",
+				"lahf_lm",
+				"abm",
+				"xsaveopt",
+				"invpcid_single",
+				"pti",
+				"retpoline",
+				"fsgsbase",
+				"bmi1",
+				"avx2",
+				"smep",
+				"bmi2",
+				"erms",
+				"invpcid"
+			]
+		},
+		"total": 1,
+		"real": 1,
+		"cores": 1
+	},
+	"current_user": "centos",
+	"dmi": {
+		"dmidecode_version": "2.12"
+	},
+	"docker": {},
+	"domain": null,
+	"ec2": {
+		"ami_id": "ami-014b38e758721be30",
+		"ami_launch_index": "0",
+		"ami_manifest_path": "(unknown)",
+		"block_device_mapping_ami": "/dev/sda1",
+		"block_device_mapping_root": "/dev/sda1",
+		"hostname": "ip-172-30-0-100.ec2.internal",
+		"instance_action": "none",
+		"instance_id": "i-0b85135210bef8573",
+		"instance_type": "t2.micro",
+		"local_hostname": "ip-172-30-0-100.ec2.internal",
+		"local_ipv4": "172.30.0.100",
+		"mac": "0a:f3:15:99:19:36",
+		"metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+		"network_interfaces_macs": {
+			"0a:f3:15:99:19:36": {
+				"device_number": "0",
+				"interface_id": "eni-016f39abbaecad9f7",
+				"ipv4-associations": {
+					"54.167.86.159": "172.30.0.100"
+				},
+				"local_hostname": "ip-172-30-0-100.ec2.internal",
+				"local_ipv4s": "172.30.0.100",
+				"mac": "0a:f3:15:99:19:36",
+				"owner_id": "399524901138",
+				"public_hostname": "",
+				"public_ipv4s": "54.167.86.159",
+				"security_group_ids": "sg-c7086ca3",
+				"security_groups": "launch-wizard-1",
+				"subnet_id": "subnet-49b5d63e",
+				"subnet_ipv4_cidr_block": "172.30.0.0/24",
+				"vpc_id": "vpc-02550367",
+				"vpc_ipv4_cidr_block": "172.30.0.0/16",
+				"vpc_ipv4_cidr_blocks": "172.30.0.0/16"
+			}
+		},
+		"placement_availability_zone": "us-east-1a",
+		"product_codes": "6x5jmcajty9edm3f211pqjfn2",
+		"profile": "default-hvm",
+		"public_hostname": "",
+		"public_ipv4": "54.167.86.159",
+		"public_keys_0_openssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiezJPkkl7W6lXMfl3x7oEs6ahrR8W35zLGxQRsnq99ShKpZnB+X20wlskUQt8PpXE+3rersJwA8euF5lTiml53K/ojM190FZAiwgvYjLe0yB/mtP8nPzh5h2G6U6Iu7eNV0C2f+rzvzy7LM8W6t8ULpS+W48Va2teVD7927BMwWVzL1g4iLRvRnOHpYkVlO9KbzUzO2mDW8giT8tRQyc7hDBiJClLxxr+hUu7i/8Rfq2esTp2aXRyvpVycfExTKGotVcLYd4+f3VH2Lmf4mR5SckGXGyym/VUOl6uaRDoTijTaf3DDL3sZiZBTEdihGidt3hlysbum2HfWKfxbGgr ohai",
+		"reservation_id": "r-0b1955bf51e5cc177",
+		"security_groups": [
+			"launch-wizard-1"
+		],
+		"services_domain": "amazonaws.com",
+		"services_partition": "aws",
+		"userdata": null,
+		"account_id": "399524901138",
+		"availability_zone": "us-east-1a",
+		"region": "us-east-1"
+	},
+	"etc": {
+		"passwd": {
+			"root": {
+				"dir": "/root",
+				"gid": "0",
+				"uid": "0",
+				"shell": "/bin/bash",
+				"gecos": "root"
+			},
+			"bin": {
+				"dir": "/bin",
+				"gid": "1",
+				"uid": "1",
+				"shell": "/sbin/nologin",
+				"gecos": "bin"
+			},
+			"daemon": {
+				"dir": "/sbin",
+				"gid": "2",
+				"uid": "2",
+				"shell": "/sbin/nologin",
+				"gecos": "daemon"
+			},
+			"adm": {
+				"dir": "/var/adm",
+				"gid": "4",
+				"uid": "3",
+				"shell": "/sbin/nologin",
+				"gecos": "adm"
+			},
+			"lp": {
+				"dir": "/var/spool/lpd",
+				"gid": "7",
+				"uid": "4",
+				"shell": "/sbin/nologin",
+				"gecos": "lp"
+			},
+			"sync": {
+				"dir": "/sbin",
+				"gid": "0",
+				"uid": "5",
+				"shell": "/bin/sync",
+				"gecos": "sync"
+			},
+			"shutdown": {
+				"dir": "/sbin",
+				"gid": "0",
+				"uid": "6",
+				"shell": "/sbin/shutdown",
+				"gecos": "shutdown"
+			},
+			"halt": {
+				"dir": "/sbin",
+				"gid": "0",
+				"uid": "7",
+				"shell": "/sbin/halt",
+				"gecos": "halt"
+			},
+			"mail": {
+				"dir": "/var/spool/mail",
+				"gid": "12",
+				"uid": "8",
+				"shell": "/sbin/nologin",
+				"gecos": "mail"
+			},
+			"uucp": {
+				"dir": "/var/spool/uucp",
+				"gid": "14",
+				"uid": "10",
+				"shell": "/sbin/nologin",
+				"gecos": "uucp"
+			},
+			"operator": {
+				"dir": "/root",
+				"gid": "0",
+				"uid": "11",
+				"shell": "/sbin/nologin",
+				"gecos": "operator"
+			},
+			"games": {
+				"dir": "/usr/games",
+				"gid": "100",
+				"uid": "12",
+				"shell": "/sbin/nologin",
+				"gecos": "games"
+			},
+			"gopher": {
+				"dir": "/var/gopher",
+				"gid": "30",
+				"uid": "13",
+				"shell": "/sbin/nologin",
+				"gecos": "gopher"
+			},
+			"ftp": {
+				"dir": "/var/ftp",
+				"gid": "50",
+				"uid": "14",
+				"shell": "/sbin/nologin",
+				"gecos": "FTP User"
+			},
+			"nobody": {
+				"dir": "/",
+				"gid": "99",
+				"uid": "99",
+				"shell": "/sbin/nologin",
+				"gecos": "Nobody"
+			},
+			"vcsa": {
+				"dir": "/dev",
+				"gid": "69",
+				"uid": "69",
+				"shell": "/sbin/nologin",
+				"gecos": "virtual console memory owner"
+			},
+			"saslauth": {
+				"dir": "/var/empty/saslauth",
+				"gid": "76",
+				"uid": "499",
+				"shell": "/sbin/nologin",
+				"gecos": "Saslauthd user"
+			},
+			"postfix": {
+				"dir": "/var/spool/postfix",
+				"gid": "89",
+				"uid": "89",
+				"shell": "/sbin/nologin",
+				"gecos": ""
+			},
+			"sshd": {
+				"dir": "/var/empty/sshd",
+				"gid": "74",
+				"uid": "74",
+				"shell": "/sbin/nologin",
+				"gecos": "Privilege-separated SSH"
+			},
+			"centos": {
+				"dir": "/home/centos",
+				"gid": "500",
+				"uid": "500",
+				"shell": "/bin/bash",
+				"gecos": "Cloud User"
+			}
+		},
+		"group": {
+			"root": {
+				"gid": "0",
+				"members": []
+			},
+			"bin": {
+				"gid": "1",
+				"members": [
+					"bin",
+					"daemon"
+				]
+			},
+			"daemon": {
+				"gid": "2",
+				"members": [
+					"bin",
+					"daemon"
+				]
+			},
+			"sys": {
+				"gid": "3",
+				"members": [
+					"bin",
+					"adm"
+				]
+			},
+			"adm": {
+				"gid": "4",
+				"members": [
+					"adm",
+					"daemon",
+					"centos"
+				]
+			},
+			"tty": {
+				"gid": "5",
+				"members": []
+			},
+			"disk": {
+				"gid": "6",
+				"members": []
+			},
+			"lp": {
+				"gid": "7",
+				"members": [
+					"daemon"
+				]
+			},
+			"mem": {
+				"gid": "8",
+				"members": []
+			},
+			"kmem": {
+				"gid": "9",
+				"members": []
+			},
+			"wheel": {
+				"gid": "10",
+				"members": [
+					"centos"
+				]
+			},
+			"mail": {
+				"gid": "12",
+				"members": [
+					"mail",
+					"postfix"
+				]
+			},
+			"uucp": {
+				"gid": "14",
+				"members": []
+			},
+			"man": {
+				"gid": "15",
+				"members": []
+			},
+			"games": {
+				"gid": "20",
+				"members": []
+			},
+			"gopher": {
+				"gid": "30",
+				"members": []
+			},
+			"video": {
+				"gid": "39",
+				"members": []
+			},
+			"dip": {
+				"gid": "40",
+				"members": []
+			},
+			"ftp": {
+				"gid": "50",
+				"members": []
+			},
+			"lock": {
+				"gid": "54",
+				"members": []
+			},
+			"audio": {
+				"gid": "63",
+				"members": []
+			},
+			"nobody": {
+				"gid": "99",
+				"members": []
+			},
+			"users": {
+				"gid": "100",
+				"members": []
+			},
+			"utmp": {
+				"gid": "22",
+				"members": []
+			},
+			"utempter": {
+				"gid": "35",
+				"members": []
+			},
+			"floppy": {
+				"gid": "19",
+				"members": []
+			},
+			"vcsa": {
+				"gid": "69",
+				"members": []
+			},
+			"cdrom": {
+				"gid": "11",
+				"members": []
+			},
+			"tape": {
+				"gid": "33",
+				"members": []
+			},
+			"dialout": {
+				"gid": "18",
+				"members": []
+			},
+			"saslauth": {
+				"gid": "76",
+				"members": []
+			},
+			"postdrop": {
+				"gid": "90",
+				"members": []
+			},
+			"postfix": {
+				"gid": "89",
+				"members": []
+			},
+			"cgred": {
+				"gid": "499",
+				"members": []
+			},
+			"sshd": {
+				"gid": "74",
+				"members": []
+			},
+			"centos": {
+				"gid": "500",
+				"members": []
+			}
+		}
+	},
+	"filesystem": {
+		"by_device": {
+			"/dev/xvda1": {
+				"kb_size": "8124856",
+				"kb_used": "748708",
+				"kb_available": "6956772",
+				"percent_used": "10%",
+				"total_inodes": "524288",
+				"inodes_used": "18664",
+				"inodes_available": "505624",
+				"inodes_percent_used": "4%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c",
+				"mounts": [
+					"/"
+				]
+			},
+			"tmpfs": {
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				],
+				"mounts": [
+					"/dev/shm"
+				]
+			},
+			"proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/proc"
+				]
+			},
+			"sysfs": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/sys"
+				]
+			},
+			"devpts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				],
+				"mounts": [
+					"/dev/pts"
+				]
+			},
+			"none": {
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/proc/sys/fs/binfmt_misc",
+					"/selinux"
+				]
+			},
+			"/dev/xvda": {
+				"mounts": []
+			},
+			"rootfs": {
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				],
+				"mounts": [
+					"/"
+				]
+			},
+			"devtmpfs": {
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				],
+				"mounts": [
+					"/dev"
+				]
+			},
+			"/proc/bus/usb": {
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/proc/bus/usb"
+				]
+			}
+		},
+		"by_mountpoint": {
+			"/": {
+				"kb_size": "8124856",
+				"kb_used": "748708",
+				"kb_available": "6956772",
+				"percent_used": "10%",
+				"total_inodes": "524288",
+				"inodes_used": "18664",
+				"inodes_available": "505624",
+				"inodes_percent_used": "4%",
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c",
+				"devices": [
+					"/dev/xvda1",
+					"rootfs"
+				]
+			},
+			"/dev/shm": {
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"proc"
+				]
+			},
+			"/sys": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"sysfs"
+				]
+			},
+			"/dev/pts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				],
+				"devices": [
+					"devpts"
+				]
+			},
+			"/proc/sys/fs/binfmt_misc": {
+				"fs_type": "binfmt_misc",
+				"mount_options": [
+					"rw"
+				],
+				"devices": [
+					"none"
+				]
+			},
+			"/dev": {
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				],
+				"devices": [
+					"devtmpfs"
+				]
+			},
+			"/selinux": {
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"none"
+				]
+			},
+			"/proc/bus/usb": {
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"/proc/bus/usb"
+				]
+			}
+		},
+		"by_pair": {
+			"/dev/xvda1,/": {
+				"device": "/dev/xvda1",
+				"kb_size": "8124856",
+				"kb_used": "748708",
+				"kb_available": "6956772",
+				"percent_used": "10%",
+				"mount": "/",
+				"total_inodes": "524288",
+				"inodes_used": "18664",
+				"inodes_available": "505624",
+				"inodes_percent_used": "4%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw"
+				],
+				"uuid": "8dd0877d-329c-4459-86c5-1429c84fcd8c"
+			},
+			"tmpfs,/dev/shm": {
+				"device": "tmpfs",
+				"kb_size": "509044",
+				"kb_used": "0",
+				"kb_available": "509044",
+				"percent_used": "0%",
+				"mount": "/dev/shm",
+				"total_inodes": "127261",
+				"inodes_used": "1",
+				"inodes_available": "127260",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+				]
+			},
+			"proc,/proc": {
+				"device": "proc",
+				"mount": "/proc",
+				"fs_type": "proc",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"sysfs,/sys": {
+				"device": "sysfs",
+				"mount": "/sys",
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"devpts,/dev/pts": {
+				"device": "devpts",
+				"mount": "/dev/pts",
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"gid=5",
+					"mode=620"
+				]
+			},
+			"none,/proc/sys/fs/binfmt_misc": {
+				"device": "none",
+				"mount": "/proc/sys/fs/binfmt_misc",
+				"fs_type": "binfmt_misc",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"/dev/xvda,": {
+				"device": "/dev/xvda"
+			},
+			"rootfs,/": {
+				"device": "rootfs",
+				"mount": "/",
+				"fs_type": "rootfs",
+				"mount_options": [
+					"rw"
+				]
+			},
+			"devtmpfs,/dev": {
+				"device": "devtmpfs",
+				"mount": "/dev",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"seclabel",
+					"relatime",
+					"size=498180k",
+					"nr_inodes=124545",
+					"mode=755"
+				]
+			},
+			"none,/selinux": {
+				"device": "none",
+				"mount": "/selinux",
+				"fs_type": "selinuxfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"/proc/bus/usb,/proc/bus/usb": {
+				"device": "/proc/bus/usb",
+				"mount": "/proc/bus/usb",
+				"fs_type": "usbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			}
+		}
+	},
+	"fips": {
+		"kernel": {
+			"enabled": false
+		}
+	},
+	"hostname": "ip-172-30-0-100",
+	"hostnamectl": {},
+	"idletime": "2 days 00 hours 36 minutes 17 seconds",
+	"idletime_seconds": 174977,
+	"init_package": "init",
+	"ip6address": "fe80::8f3:15ff:fe99:1936",
+	"ipaddress": "172.30.0.100",
+	"kernel": {
+		"name": "Linux",
+		"release": "2.6.32-754.10.1.el6.x86_64",
+		"version": "#1 SMP Tue Jan 15 17:07:28 UTC 2019",
+		"machine": "x86_64",
+		"processor": "x86_64",
+		"os": "GNU/Linux",
+		"modules": {
+			"ipt_REJECT": {
+				"size": "2383",
+				"refcount": "2"
+			},
+			"nf_conntrack_ipv4": {
+				"size": "9218",
+				"refcount": "2"
+			},
+			"nf_defrag_ipv4": {
+				"size": "1483",
+				"refcount": "1"
+			},
+			"iptable_filter": {
+				"size": "2793",
+				"refcount": "1"
+			},
+			"ip_tables": {
+				"size": "17895",
+				"refcount": "1"
+			},
+			"ip6t_REJECT": {
+				"size": "4372",
+				"refcount": "2"
+			},
+			"nf_conntrack_ipv6": {
+				"size": "7985",
+				"refcount": "3"
+			},
+			"nf_defrag_ipv6": {
+				"size": "26637",
+				"refcount": "1"
+			},
+			"xt_state": {
+				"size": "1492",
+				"refcount": "5"
+			},
+			"nf_conntrack": {
+				"size": "79761",
+				"refcount": "3"
+			},
+			"ip6table_filter": {
+				"size": "2889",
+				"refcount": "1"
+			},
+			"ip6_tables": {
+				"size": "18828",
+				"refcount": "1"
+			},
+			"ib_ipoib": {
+				"size": "81191",
+				"refcount": "0",
+				"version": "1.0.0"
+			},
+			"rdma_ucm": {
+				"size": "15739",
+				"refcount": "0"
+			},
+			"ib_ucm": {
+				"size": "12360",
+				"refcount": "0"
+			},
+			"ib_uverbs": {
+				"size": "40564",
+				"refcount": "2"
+			},
+			"ib_umad": {
+				"size": "13519",
+				"refcount": "0"
+			},
+			"rdma_cm": {
+				"size": "36651",
+				"refcount": "1"
+			},
+			"ib_cm": {
+				"size": "37444",
+				"refcount": "3"
+			},
+			"iw_cm": {
+				"size": "33136",
+				"refcount": "1"
+			},
+			"ib_sa": {
+				"size": "24188",
+				"refcount": "4"
+			},
+			"ib_mad": {
+				"size": "41628",
+				"refcount": "3"
+			},
+			"ib_core": {
+				"size": "83376",
+				"refcount": "10"
+			},
+			"ib_addr": {
+				"size": "8304",
+				"refcount": "3"
+			},
+			"ipv6": {
+				"size": "337436",
+				"refcount": "45"
+			},
+			"xen_netfront": {
+				"size": "18930",
+				"refcount": "0"
+			},
+			"i2c_piix4": {
+				"size": "11520",
+				"refcount": "0"
+			},
+			"i2c_core": {
+				"size": "29164",
+				"refcount": "1"
+			},
+			"ext4": {
+				"size": "381616",
+				"refcount": "1"
+			},
+			"jbd2": {
+				"size": "93380",
+				"refcount": "1"
+			},
+			"mbcache": {
+				"size": "8193",
+				"refcount": "1"
+			},
+			"xen_blkfront": {
+				"size": "21966",
+				"refcount": "2"
+			},
+			"pata_acpi": {
+				"size": "3701",
+				"refcount": "0",
+				"version": "0.2.3"
+			},
+			"ata_generic": {
+				"size": "3837",
+				"refcount": "0",
+				"version": "0.2.15"
+			},
+			"ata_piix": {
+				"size": "24409",
+				"refcount": "0",
+				"version": "2.13"
+			},
+			"dm_mirror": {
+				"size": "14864",
+				"refcount": "0"
+			},
+			"dm_region_hash": {
+				"size": "12181",
+				"refcount": "1"
+			},
+			"dm_log": {
+				"size": "9930",
+				"refcount": "2"
+			},
+			"dm_mod": {
+				"size": "102823",
+				"refcount": "2"
+			}
+		}
+	},
+	"keys": {
+		"ssh": {
+			"host_dsa_public": "AAAAB3NzaC1kc3MAAACBANKeSCP1+yr7R1meCHLhKv2Hcl1Rt0vbSCxQnhLMIp8drd/sQywYYkbslb2JXidoyBMqKMg+RD9ye7uutpdAX7Qx3FWy5XB1NzXMeYX1xfCpuPLiaGmjz6YivtVMYM+umZ9viMVRY6BEiPXOvxcYiiLJ/0WcvCoQpv/I1W2oB6gbAAAAFQDF08gwxsrV4TCbPN5wQcqOI2NXDQAAAIAL7hPfQX9q1EZYgZBI4llR/SLtZNoCOXO29Y4XyjP9UVqLFVc/XziPA96jR0tY3h6M0MF1Uy3wj8wkAVE6le6gmdJB8bQS5TpQ17j8gQmkbVHIuY0ulsdbWBMDxeZoFFkCBUu6jbd3740OF6o5M80mPb5Rn/8RPDTsB4vVsdfgXgAAAIBe/vrgWmqNgk3AffGxc46lYKtLSzmbdDbVmVSn6PxAHoDpDbsNemv8HYw9NrifB0a/Rx4cHYHfkdi9xfm9Sh6qk4oouMhwoYSRWip+slm/KPWmh9y8aea8dZAVFHbyytRryiEg3SCdvlN6DEvpQ483oVxFAsi0LFhaxsQp+LqMrQ==",
+			"host_rsa_public": "AAAAB3NzaC1yc2EAAAABIwAAAQEAymMo33IJjf/18r7QWlkvgURnxm/4zdho/hJvcNrYcT2sHjsispOG+A+QPWlB0G+Y3y5hnlqy0PTeAFkfrbpr4tRkBoP9zMC4FpN3V5GglBtfdYdt6NWCqhCTWwAcq3GmNTMy1s280oQTxc6CzAHxfADB4Jp1PhtLIj2dsRPuEXwLnUGyc+ZKurSQN+ArPMac7A+npl/PjAhE8lYDyDXDz226U0rq25Rc0MgtdZnuFtpFFyVZ2bjsDYlJEs27b+qFTktCinGcRZCzzbZlNrNBPWmhqVihDoRRm8nzhLsfeHbHEoN8ou6ney8hym1OIx6eXWZTrHW/nZwXBP8++0AIdw=="
+		}
+	},
+	"languages": {
+		"python": {
+			"version": "2.6.6",
+			"builddate": "Aug 18 2016, 15:13:37"
+		},
+		"c": {
+			"glibc": {
+				"version": "2.12",
+				"description": "GNU C Library stable release version 2.12, by Roland McGrath et al."
+			}
+		},
+		"ruby": {},
+		"lua": {
+			"version": "5.1.4"
+		}
+	},
+	"lsb": {},
+	"macaddress": "0A:F3:15:99:19:36",
+	"machinename": "ip-172-30-0-100",
+	"memory": {
+		"swap": {
+			"cached": "0kB",
+			"total": "0kB",
+			"free": "0kB"
+		},
+		"hugepages": {
+			"total": "0",
+			"free": "0",
+			"reserved": "0",
+			"surplus": "0"
+		},
+		"directmap": {
+			"4k": "12288kB",
+			"2M": "1036288kB"
+		},
+		"total": "1018092kB",
+		"free": "697848kB",
+		"buffers": "97932kB",
+		"cached": "119668kB",
+		"active": "131436kB",
+		"inactive": "100392kB",
+		"dirty": "28kB",
+		"writeback": "0kB",
+		"anon_pages": "14248kB",
+		"mapped": "6628kB",
+		"slab": "70396kB",
+		"slab_reclaimable": "16844kB",
+		"slab_unreclaim": "53552kB",
+		"page_tables": "2104kB",
+		"nfs_unstable": "0kB",
+		"bounce": "0kB",
+		"commit_limit": "509044kB",
+		"committed_as": "66508kB",
+		"vmalloc_total": "34359738367kB",
+		"vmalloc_used": "9548kB",
+		"vmalloc_chunk": "34359726716kB",
+		"hugepage_size": "2048kB"
+	},
+	"network": {
+		"interfaces": {
+			"lo": {
+				"mtu": "65536",
+				"flags": [
+					"LOOPBACK",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Loopback",
+				"addresses": {
+					"127.0.0.1": {
+						"family": "inet",
+						"prefixlen": "8",
+						"netmask": "255.0.0.0",
+						"scope": "Node"
+					},
+					"::1": {
+						"family": "inet6",
+						"prefixlen": "128",
+						"scope": "Node",
+						"tags": []
+					}
+				},
+				"state": "unknown",
+				"routes": [
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					},
+					{
+						"destination": "unreachable",
+						"family": "inet6",
+						"metric": "1024"
+					}
+				]
+			},
+			"eth0": {
+				"type": "eth",
+				"number": "0",
+				"mtu": "9001",
+				"flags": [
+					"BROADCAST",
+					"MULTICAST",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Ethernet",
+				"addresses": {
+					"0A:F3:15:99:19:36": {
+						"family": "lladdr"
+					},
+					"172.30.0.100": {
+						"family": "inet",
+						"prefixlen": "24",
+						"netmask": "255.255.255.0",
+						"broadcast": "172.30.0.255",
+						"scope": "Global"
+					},
+					"fe80::8f3:15ff:fe99:1936": {
+						"family": "inet6",
+						"prefixlen": "64",
+						"scope": "Link",
+						"tags": []
+					}
+				},
+				"state": "up",
+				"arp": {
+					"172.30.0.2": "0a:e7:37:d9:20:26",
+					"172.30.0.1": "0a:e7:37:d9:20:26"
+				},
+				"routes": [
+					{
+						"destination": "172.30.0.0/24",
+						"family": "inet",
+						"scope": "link",
+						"proto": "kernel",
+						"src": "172.30.0.100"
+					},
+					{
+						"destination": "default",
+						"family": "inet",
+						"via": "172.30.0.1"
+					},
+					{
+						"destination": "fe80::/64",
+						"family": "inet6",
+						"metric": "256",
+						"proto": "kernel"
+					}
+				],
+				"ring_params": {}
+			}
+		},
+		"default_interface": "eth0",
+		"default_gateway": "172.30.0.1"
+	},
+	"ohai_time": 1554223206.436435,
+	"os": "linux",
+	"os_version": "2.6.32-754.10.1.el6.x86_64",
+	"packages": {
+		"setup": {
+			"epoch": "0",
+			"version": "2.8.14",
+			"release": "23.el6",
+			"installdate": "1548708518",
+			"arch": "noarch"
+		},
+		"basesystem": {
+			"epoch": "0",
+			"version": "10.0",
+			"release": "4.el6",
+			"installdate": "1548708519",
+			"arch": "noarch"
+		},
+		"tzdata": {
+			"epoch": "0",
+			"version": "2018i",
+			"release": "1.el6",
+			"installdate": "1548708520",
+			"arch": "noarch"
+		},
+		"nss-softokn-freebl": {
+			"epoch": "0",
+			"version": "3.14.3",
+			"release": "23.3.el6_8",
+			"installdate": "1548708527",
+			"arch": "x86_64"
+		},
+		"ncurses-libs": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"libattr": {
+			"epoch": "0",
+			"version": "2.4.44",
+			"release": "7.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"zlib": {
+			"epoch": "0",
+			"version": "1.2.3",
+			"release": "29.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"audit-libs": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"bzip2-libs": {
+			"epoch": "0",
+			"version": "1.0.5",
+			"release": "7.el6_0",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libcom_err": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"db4": {
+			"epoch": "0",
+			"version": "4.7.25",
+			"release": "22.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libselinux": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"sed": {
+			"epoch": "0",
+			"version": "4.2.1",
+			"release": "10.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"xz-libs": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"gawk": {
+			"epoch": "0",
+			"version": "3.1.7",
+			"release": "10.el6_7.3",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"sqlite": {
+			"epoch": "0",
+			"version": "3.6.20",
+			"release": "1.el6_7.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"file-libs": {
+			"epoch": "0",
+			"version": "5.04",
+			"release": "30.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"dbus-libs": {
+			"epoch": "1",
+			"version": "1.2.24",
+			"release": "9.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"pcre": {
+			"epoch": "0",
+			"version": "7.8",
+			"release": "7.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"findutils": {
+			"epoch": "1",
+			"version": "4.4.2",
+			"release": "9.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"bzip2": {
+			"epoch": "0",
+			"version": "1.0.5",
+			"release": "7.el6_0",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libuuid": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libgpg-error": {
+			"epoch": "0",
+			"version": "1.7",
+			"release": "4.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"procps": {
+			"epoch": "0",
+			"version": "3.2.8",
+			"release": "45.el6_9.3",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libselinux-utils": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"cpio": {
+			"epoch": "0",
+			"version": "2.10",
+			"release": "13.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"tcp_wrappers-libs": {
+			"epoch": "0",
+			"version": "7.6",
+			"release": "58.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"sysvinit-tools": {
+			"epoch": "0",
+			"version": "2.87",
+			"release": "6.dsf.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libudev": {
+			"epoch": "0",
+			"version": "147",
+			"release": "2.73.el6_8.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libtasn1": {
+			"epoch": "0",
+			"version": "2.3",
+			"release": "6.el6_5",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"p11-kit-trust": {
+			"epoch": "0",
+			"version": "0.18.5",
+			"release": "2.el6_5.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libnih": {
+			"epoch": "0",
+			"version": "1.0.1",
+			"release": "8.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"setools-libs": {
+			"epoch": "0",
+			"version": "3.3.7",
+			"release": "4.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"elfutils-libs": {
+			"epoch": "0",
+			"version": "0.164",
+			"release": "2.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"gmp": {
+			"epoch": "0",
+			"version": "4.3.1",
+			"release": "13.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"libusb": {
+			"epoch": "0",
+			"version": "0.1.12",
+			"release": "23.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"xz-lzma-compat": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"vim-minimal": {
+			"epoch": "2",
+			"version": "7.4.629",
+			"release": "5.el6_8.1",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"tar": {
+			"epoch": "2",
+			"version": "1.23",
+			"release": "15.el6_8",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"libss": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"e2fsprogs": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"which": {
+			"epoch": "0",
+			"version": "2.19",
+			"release": "6.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"m4": {
+			"epoch": "0",
+			"version": "1.4.13",
+			"release": "5.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"ncurses": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"less": {
+			"epoch": "0",
+			"version": "436",
+			"release": "13.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"gzip": {
+			"epoch": "0",
+			"version": "1.3.12",
+			"release": "24.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"cracklib-dicts": {
+			"epoch": "0",
+			"version": "2.8.16",
+			"release": "4.el6",
+			"installdate": "1548708535",
+			"arch": "x86_64"
+		},
+		"pam": {
+			"epoch": "0",
+			"version": "1.1.1",
+			"release": "24.el6",
+			"installdate": "1548708536",
+			"arch": "x86_64"
+		},
+		"hwdata": {
+			"epoch": "0",
+			"version": "0.233",
+			"release": "20.1.el6",
+			"installdate": "1548708536",
+			"arch": "noarch"
+		},
+		"redhat-logos": {
+			"epoch": "0",
+			"version": "60.0.14",
+			"release": "12.el6.centos",
+			"installdate": "1548708538",
+			"arch": "noarch"
+		},
+		"pciutils": {
+			"epoch": "0",
+			"version": "3.1.10",
+			"release": "4.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"logrotate": {
+			"epoch": "0",
+			"version": "3.7.8",
+			"release": "28.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss-sysinit": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libedit": {
+			"epoch": "0",
+			"version": "2.11",
+			"release": "4.20080712cvs.1.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libcap-ng": {
+			"epoch": "0",
+			"version": "0.6.4",
+			"release": "3.el6_0.1",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"mingetty": {
+			"epoch": "0",
+			"version": "1.08",
+			"release": "5.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libyaml": {
+			"epoch": "0",
+			"version": "0.1.3",
+			"release": "4.el6_6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"krb5-libs": {
+			"epoch": "0",
+			"version": "1.10.3",
+			"release": "65.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libssh2": {
+			"epoch": "0",
+			"version": "1.4.2",
+			"release": "2.el6_7.1",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"rpm-libs": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"rpm": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"gnupg2": {
+			"epoch": "0",
+			"version": "2.0.14",
+			"release": "9.el6_10",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"deltarpm": {
+			"epoch": "0",
+			"version": "3.5",
+			"release": "0.5.20090913git.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"fipscheck-lib": {
+			"epoch": "0",
+			"version": "1.2.0",
+			"release": "7.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"ustr": {
+			"epoch": "0",
+			"version": "1.0.4",
+			"release": "9.1.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"shadow-utils": {
+			"epoch": "2",
+			"version": "4.1.5.1",
+			"release": "5.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"MAKEDEV": {
+			"epoch": "0",
+			"version": "3.24",
+			"release": "6.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"newt": {
+			"epoch": "0",
+			"version": "0.52.11",
+			"release": "4.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"gdbm": {
+			"epoch": "0",
+			"version": "1.8.0",
+			"release": "39.el6",
+			"installdate": "1548708544",
+			"arch": "x86_64"
+		},
+		"python": {
+			"epoch": "0",
+			"version": "2.6.6",
+			"release": "66.el6_8",
+			"installdate": "1548708545",
+			"arch": "x86_64"
+		},
+		"libselinux-python": {
+			"epoch": "0",
+			"version": "2.0.94",
+			"release": "7.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"rpm-python": {
+			"epoch": "0",
+			"version": "4.8.0",
+			"release": "59.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"libsemanage-python": {
+			"epoch": "0",
+			"version": "2.0.43",
+			"release": "5.1.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"m2crypto": {
+			"epoch": "0",
+			"version": "0.20.2",
+			"release": "9.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-urlgrabber": {
+			"epoch": "0",
+			"version": "3.9.1",
+			"release": "11.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-prettytable": {
+			"epoch": "0",
+			"version": "0.7.2",
+			"release": "11.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-configobj": {
+			"epoch": "0",
+			"version": "4.6.0",
+			"release": "3.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-iniparse": {
+			"epoch": "0",
+			"version": "0.3.1",
+			"release": "2.1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-markdown": {
+			"epoch": "0",
+			"version": "2.0.1",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-jsonpatch": {
+			"epoch": "0",
+			"version": "1.2",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-setuptools": {
+			"epoch": "0",
+			"version": "0.6.10",
+			"release": "4.el6_9",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-cheetah": {
+			"epoch": "0",
+			"version": "2.4.1",
+			"release": "1.el6",
+			"installdate": "1548708550",
+			"arch": "x86_64"
+		},
+		"python-backports": {
+			"epoch": "0",
+			"version": "1.0",
+			"release": "5.el6",
+			"installdate": "1548708550",
+			"arch": "x86_64"
+		},
+		"python-urllib3": {
+			"epoch": "0",
+			"version": "1.10.2",
+			"release": "3.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-boto": {
+			"epoch": "1",
+			"version": "2.34.0",
+			"release": "6.el6",
+			"installdate": "1548708552",
+			"arch": "noarch"
+		},
+		"gamin": {
+			"epoch": "0",
+			"version": "0.1.10",
+			"release": "9.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"shared-mime-info": {
+			"epoch": "0",
+			"version": "0.70",
+			"release": "6.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"libuser": {
+			"epoch": "0",
+			"version": "0.56.13",
+			"release": "8.el6_7",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum-metadata-parser": {
+			"epoch": "0",
+			"version": "1.1.2",
+			"release": "16.el6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum": {
+			"epoch": "0",
+			"version": "3.2.29",
+			"release": "81.el6.centos.0.1",
+			"installdate": "1548708553",
+			"arch": "noarch"
+		},
+		"kernel-firmware": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "754.10.1.el6",
+			"installdate": "1548708557",
+			"arch": "noarch"
+		},
+		"centos-release": {
+			"epoch": "0",
+			"version": "6",
+			"release": "10.el6.centos.12.3",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iptables": {
+			"epoch": "0",
+			"version": "1.4.7",
+			"release": "19.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"libdrm": {
+			"epoch": "0",
+			"version": "2.4.65",
+			"release": "2.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iputils": {
+			"epoch": "0",
+			"version": "20071127",
+			"release": "24.el6",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"initscripts": {
+			"epoch": "0",
+			"version": "9.03.61",
+			"release": "1.el6.centos",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"rsyslog": {
+			"epoch": "0",
+			"version": "5.8.10",
+			"release": "12.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"mdadm": {
+			"epoch": "0",
+			"version": "3.3.4",
+			"release": "8.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"device-mapper": {
+			"epoch": "0",
+			"version": "1.02.117",
+			"release": "12.el6_9.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"kbd": {
+			"epoch": "0",
+			"version": "1.15",
+			"release": "11.el6",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"dracut-kernel": {
+			"epoch": "0",
+			"version": "004",
+			"release": "411.el6",
+			"installdate": "1548708561",
+			"arch": "noarch"
+		},
+		"postfix": {
+			"epoch": "2",
+			"version": "2.6.6",
+			"release": "8.el6",
+			"installdate": "1548708562",
+			"arch": "x86_64"
+		},
+		"cronie-anacron": {
+			"epoch": "0",
+			"version": "1.4.4",
+			"release": "16.el6_8.2",
+			"installdate": "1548708563",
+			"arch": "x86_64"
+		},
+		"libcgroup": {
+			"epoch": "0",
+			"version": "0.40.rc1",
+			"release": "27.el6_10",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"iptables-ipv6": {
+			"epoch": "0",
+			"version": "1.4.7",
+			"release": "19.el6",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"selinux-policy": {
+			"epoch": "0",
+			"version": "3.7.19",
+			"release": "312.el6",
+			"installdate": "1548708568",
+			"arch": "noarch"
+		},
+		"dhclient": {
+			"epoch": "12",
+			"version": "4.1.1",
+			"release": "63.P1.el6.centos",
+			"installdate": "1548708568",
+			"arch": "x86_64"
+		},
+		"system-config-firewall-tui": {
+			"epoch": "0",
+			"version": "1.2.27",
+			"release": "7.2.el6_6",
+			"installdate": "1548708595",
+			"arch": "noarch"
+		},
+		"kernel": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "754.10.1.el6",
+			"installdate": "1548708605",
+			"arch": "x86_64"
+		},
+		"kexec-tools": {
+			"epoch": "0",
+			"version": "2.0.0",
+			"release": "310.el6",
+			"installdate": "1548708606",
+			"arch": "x86_64"
+		},
+		"openssh-server": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"acpid": {
+			"epoch": "0",
+			"version": "1.0.10",
+			"release": "3.el6",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"passwd": {
+			"epoch": "0",
+			"version": "0.77",
+			"release": "7.el6",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"sudo": {
+			"epoch": "0",
+			"version": "1.8.6p3",
+			"release": "29.el6_9",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"audit": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"rsync": {
+			"epoch": "0",
+			"version": "3.0.6",
+			"release": "12.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"attr": {
+			"epoch": "0",
+			"version": "2.4.44",
+			"release": "7.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"libgcc": {
+			"epoch": "0",
+			"version": "4.4.7",
+			"release": "23.el6",
+			"installdate": "1548708518",
+			"arch": "x86_64"
+		},
+		"filesystem": {
+			"epoch": "0",
+			"version": "2.4.30",
+			"release": "3.el6",
+			"installdate": "1548708518",
+			"arch": "x86_64"
+		},
+		"ncurses-base": {
+			"epoch": "0",
+			"version": "5.7",
+			"release": "4.20090207.el6",
+			"installdate": "1548708519",
+			"arch": "x86_64"
+		},
+		"glibc-common": {
+			"epoch": "0",
+			"version": "2.12",
+			"release": "1.212.el6",
+			"installdate": "1548708525",
+			"arch": "x86_64"
+		},
+		"glibc": {
+			"epoch": "0",
+			"version": "2.12",
+			"release": "1.212.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"bash": {
+			"epoch": "0",
+			"version": "4.1.2",
+			"release": "48.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"libcap": {
+			"epoch": "0",
+			"version": "2.16",
+			"release": "5.5.el6",
+			"installdate": "1548708528",
+			"arch": "x86_64"
+		},
+		"info": {
+			"epoch": "0",
+			"version": "4.13a",
+			"release": "8.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"popt": {
+			"epoch": "0",
+			"version": "1.13",
+			"release": "7.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libacl": {
+			"epoch": "0",
+			"version": "2.2.49",
+			"release": "7.el6_9.1",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"nspr": {
+			"epoch": "0",
+			"version": "4.19.0",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libsepol": {
+			"epoch": "0",
+			"version": "2.0.41",
+			"release": "4.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"chkconfig": {
+			"epoch": "0",
+			"version": "1.3.49.5",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"nss-util": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "1.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"libstdc++": {
+			"epoch": "0",
+			"version": "4.4.7",
+			"release": "23.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"readline": {
+			"epoch": "0",
+			"version": "6.0",
+			"release": "4.el6",
+			"installdate": "1548708529",
+			"arch": "x86_64"
+		},
+		"elfutils-libelf": {
+			"epoch": "0",
+			"version": "0.164",
+			"release": "2.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libxml2": {
+			"epoch": "0",
+			"version": "2.7.6",
+			"release": "21.el6_8.1",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"lua": {
+			"epoch": "0",
+			"version": "5.1.4",
+			"release": "4.1.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"grep": {
+			"epoch": "0",
+			"version": "2.20",
+			"release": "6.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"cyrus-sasl-lib": {
+			"epoch": "0",
+			"version": "2.1.23",
+			"release": "15.el6_6.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libidn": {
+			"epoch": "0",
+			"version": "1.18",
+			"release": "2.el6",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"libblkid": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708530",
+			"arch": "x86_64"
+		},
+		"nss-softokn": {
+			"epoch": "0",
+			"version": "3.14.3",
+			"release": "23.3.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"net-tools": {
+			"epoch": "0",
+			"version": "1.60",
+			"release": "114.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"checkpolicy": {
+			"epoch": "0",
+			"version": "2.0.22",
+			"release": "1.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"make": {
+			"epoch": "1",
+			"version": "3.81",
+			"release": "23.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"pciutils-libs": {
+			"epoch": "0",
+			"version": "3.1.10",
+			"release": "4.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"expat": {
+			"epoch": "0",
+			"version": "2.0.1",
+			"release": "13.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"pth": {
+			"epoch": "0",
+			"version": "2.0.7",
+			"release": "9.3.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"p11-kit": {
+			"epoch": "0",
+			"version": "0.18.5",
+			"release": "2.el6_5.2",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"libgcrypt": {
+			"epoch": "0",
+			"version": "1.4.5",
+			"release": "12.el6_8",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"upstart": {
+			"epoch": "0",
+			"version": "0.6.5",
+			"release": "17.el6",
+			"installdate": "1548708531",
+			"arch": "x86_64"
+		},
+		"file": {
+			"epoch": "0",
+			"version": "5.04",
+			"release": "30.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"bc": {
+			"epoch": "0",
+			"version": "1.06.95",
+			"release": "1.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"snappy": {
+			"epoch": "0",
+			"version": "1.1.0",
+			"release": "1.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"xz": {
+			"epoch": "0",
+			"version": "4.999.9",
+			"release": "0.5.beta.20091007git.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"pinentry": {
+			"epoch": "0",
+			"version": "0.7.6",
+			"release": "8.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"psmisc": {
+			"epoch": "0",
+			"version": "22.6",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"db4-utils": {
+			"epoch": "0",
+			"version": "4.7.25",
+			"release": "22.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"e2fsprogs-libs": {
+			"epoch": "0",
+			"version": "1.41.12",
+			"release": "24.el6",
+			"installdate": "1548708532",
+			"arch": "x86_64"
+		},
+		"diffutils": {
+			"epoch": "0",
+			"version": "2.8.1",
+			"release": "28.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"binutils": {
+			"epoch": "0",
+			"version": "2.20.51.0.2",
+			"release": "5.48.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"dash": {
+			"epoch": "0",
+			"version": "0.5.5.1",
+			"release": "4.el6",
+			"installdate": "1548708533",
+			"arch": "x86_64"
+		},
+		"groff": {
+			"epoch": "0",
+			"version": "1.18.1.4",
+			"release": "21.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"coreutils-libs": {
+			"epoch": "0",
+			"version": "8.4",
+			"release": "47.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"cracklib": {
+			"epoch": "0",
+			"version": "2.8.16",
+			"release": "4.el6",
+			"installdate": "1548708534",
+			"arch": "x86_64"
+		},
+		"coreutils": {
+			"epoch": "0",
+			"version": "8.4",
+			"release": "47.el6",
+			"installdate": "1548708535",
+			"arch": "x86_64"
+		},
+		"module-init-tools": {
+			"epoch": "0",
+			"version": "3.9",
+			"release": "26.el6",
+			"installdate": "1548708536",
+			"arch": "x86_64"
+		},
+		"ca-certificates": {
+			"epoch": "0",
+			"version": "2018.2.22",
+			"release": "65.1.el6",
+			"installdate": "1548708536",
+			"arch": "noarch"
+		},
+		"plymouth-scripts": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"libpciaccess": {
+			"epoch": "0",
+			"version": "0.13.4",
+			"release": "1.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"nss-tools": {
+			"epoch": "0",
+			"version": "3.36.0",
+			"release": "9.el6_10",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"dmidecode": {
+			"epoch": "1",
+			"version": "2.12",
+			"release": "7.el6",
+			"installdate": "1548708538",
+			"arch": "x86_64"
+		},
+		"ethtool": {
+			"epoch": "2",
+			"version": "3.5",
+			"release": "6.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"lzo": {
+			"epoch": "0",
+			"version": "2.03",
+			"release": "3.1.el6_5.1",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"keyutils-libs": {
+			"epoch": "0",
+			"version": "1.4",
+			"release": "5.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"openssl": {
+			"epoch": "0",
+			"version": "1.0.1e",
+			"release": "57.el6",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"libcurl": {
+			"epoch": "0",
+			"version": "7.19.7",
+			"release": "53.el6_9",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"curl": {
+			"epoch": "0",
+			"version": "7.19.7",
+			"release": "53.el6_9",
+			"installdate": "1548708539",
+			"arch": "x86_64"
+		},
+		"openldap": {
+			"epoch": "0",
+			"version": "2.4.40",
+			"release": "16.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"gpgme": {
+			"epoch": "0",
+			"version": "1.1.8",
+			"release": "3.el6",
+			"installdate": "1548708540",
+			"arch": "x86_64"
+		},
+		"mysql-libs": {
+			"epoch": "0",
+			"version": "5.1.73",
+			"release": "8.el6_8",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"fipscheck": {
+			"epoch": "0",
+			"version": "1.2.0",
+			"release": "7.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"libsemanage": {
+			"epoch": "0",
+			"version": "2.0.43",
+			"release": "5.1.el6",
+			"installdate": "1548708541",
+			"arch": "x86_64"
+		},
+		"libutempter": {
+			"epoch": "0",
+			"version": "1.1.5",
+			"release": "4.1.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"slang": {
+			"epoch": "0",
+			"version": "2.2.1",
+			"release": "1.el6",
+			"installdate": "1548708542",
+			"arch": "x86_64"
+		},
+		"plymouth-core-libs": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708543",
+			"arch": "x86_64"
+		},
+		"libffi": {
+			"epoch": "0",
+			"version": "3.0.5",
+			"release": "3.2.el6",
+			"installdate": "1548708545",
+			"arch": "x86_64"
+		},
+		"python-libs": {
+			"epoch": "0",
+			"version": "2.6.6",
+			"release": "66.el6_8",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"PyYAML": {
+			"epoch": "0",
+			"version": "3.10",
+			"release": "3.1.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"pygpgme": {
+			"epoch": "0",
+			"version": "0.1",
+			"release": "18.20090824bzr68.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"setools-libs-python": {
+			"epoch": "0",
+			"version": "3.3.7",
+			"release": "4.el6",
+			"installdate": "1548708548",
+			"arch": "x86_64"
+		},
+		"python-pycurl": {
+			"epoch": "0",
+			"version": "7.19.0",
+			"release": "9.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"newt-python": {
+			"epoch": "0",
+			"version": "0.52.11",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-oauth": {
+			"epoch": "0",
+			"version": "1.0.1",
+			"release": "1.el6.centos",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-argparse": {
+			"epoch": "0",
+			"version": "1.2.1",
+			"release": "2.1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"audit-libs-python": {
+			"epoch": "0",
+			"version": "2.4.5",
+			"release": "6.el6",
+			"installdate": "1548708549",
+			"arch": "x86_64"
+		},
+		"python-jsonpointer": {
+			"epoch": "0",
+			"version": "1.0",
+			"release": "4.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-chardet": {
+			"epoch": "0",
+			"version": "2.2.1",
+			"release": "1.el6",
+			"installdate": "1548708549",
+			"arch": "noarch"
+		},
+		"python-pygments": {
+			"epoch": "0",
+			"version": "1.1.1",
+			"release": "2.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-six": {
+			"epoch": "0",
+			"version": "1.9.0",
+			"release": "2.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-backports-ssl_match_hostname": {
+			"epoch": "0",
+			"version": "3.4.0.2",
+			"release": "5.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"python-requests": {
+			"epoch": "0",
+			"version": "2.6.0",
+			"release": "4.el6",
+			"installdate": "1548708550",
+			"arch": "noarch"
+		},
+		"pkgconfig": {
+			"epoch": "1",
+			"version": "0.23",
+			"release": "9.1.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"glib2": {
+			"epoch": "0",
+			"version": "2.28.8",
+			"release": "10.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"grubby": {
+			"epoch": "0",
+			"version": "7.0.15",
+			"release": "7.el6",
+			"installdate": "1548708552",
+			"arch": "x86_64"
+		},
+		"dbus-glib": {
+			"epoch": "0",
+			"version": "0.86",
+			"release": "6.el6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"yum-plugin-fastestmirror": {
+			"epoch": "0",
+			"version": "1.1.30",
+			"release": "42.el6_10",
+			"installdate": "1548708553",
+			"arch": "noarch"
+		},
+		"busybox": {
+			"epoch": "1",
+			"version": "1.15.1",
+			"release": "21.el6_6",
+			"installdate": "1548708553",
+			"arch": "x86_64"
+		},
+		"kbd-misc": {
+			"epoch": "0",
+			"version": "1.15",
+			"release": "11.el6",
+			"installdate": "1548708558",
+			"arch": "noarch"
+		},
+		"policycoreutils": {
+			"epoch": "0",
+			"version": "2.0.83",
+			"release": "30.1.el6_8",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"iproute": {
+			"epoch": "0",
+			"version": "2.6.32",
+			"release": "57.el6",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"plymouth": {
+			"epoch": "0",
+			"version": "0.8.3",
+			"release": "29.el6.centos",
+			"installdate": "1548708558",
+			"arch": "x86_64"
+		},
+		"util-linux-ng": {
+			"epoch": "0",
+			"version": "2.17.2",
+			"release": "12.28.el6_9.2",
+			"installdate": "1548708559",
+			"arch": "x86_64"
+		},
+		"udev": {
+			"epoch": "0",
+			"version": "147",
+			"release": "2.73.el6_8.2",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"openssh": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"device-mapper-libs": {
+			"epoch": "0",
+			"version": "1.02.117",
+			"release": "12.el6_9.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"kpartx": {
+			"epoch": "0",
+			"version": "0.4.9",
+			"release": "106.el6_10.1",
+			"installdate": "1548708560",
+			"arch": "x86_64"
+		},
+		"dracut": {
+			"epoch": "0",
+			"version": "004",
+			"release": "411.el6",
+			"installdate": "1548708561",
+			"arch": "noarch"
+		},
+		"cyrus-sasl": {
+			"epoch": "0",
+			"version": "2.1.23",
+			"release": "15.el6_6.2",
+			"installdate": "1548708561",
+			"arch": "x86_64"
+		},
+		"crontabs": {
+			"epoch": "0",
+			"version": "1.10",
+			"release": "33.el6",
+			"installdate": "1548708563",
+			"arch": "noarch"
+		},
+		"cronie": {
+			"epoch": "0",
+			"version": "1.4.4",
+			"release": "16.el6_8.2",
+			"installdate": "1548708563",
+			"arch": "x86_64"
+		},
+		"policycoreutils-python": {
+			"epoch": "0",
+			"version": "2.0.83",
+			"release": "30.1.el6_8",
+			"installdate": "1548708567",
+			"arch": "x86_64"
+		},
+		"system-config-firewall-base": {
+			"epoch": "0",
+			"version": "1.2.27",
+			"release": "7.2.el6_6",
+			"installdate": "1548708567",
+			"arch": "noarch"
+		},
+		"dhcp-common": {
+			"epoch": "12",
+			"version": "4.1.1",
+			"release": "63.P1.el6.centos",
+			"installdate": "1548708568",
+			"arch": "x86_64"
+		},
+		"selinux-policy-targeted": {
+			"epoch": "0",
+			"version": "3.7.19",
+			"release": "312.el6",
+			"installdate": "1548708569",
+			"arch": "noarch"
+		},
+		"cloud-init": {
+			"epoch": "0",
+			"version": "0.7.5",
+			"release": "10.el6.centos.2",
+			"installdate": "1548708596",
+			"arch": "x86_64"
+		},
+		"rdma": {
+			"epoch": "0",
+			"version": "6.9_4.1",
+			"release": "3.el6",
+			"installdate": "1548708606",
+			"arch": "noarch"
+		},
+		"openssh-clients": {
+			"epoch": "0",
+			"version": "5.3p1",
+			"release": "123.el6_9",
+			"installdate": "1548708607",
+			"arch": "x86_64"
+		},
+		"b43-openfwwf": {
+			"epoch": "0",
+			"version": "5.2",
+			"release": "10.el6",
+			"installdate": "1548708607",
+			"arch": "noarch"
+		},
+		"yum-presto": {
+			"epoch": "0",
+			"version": "0.6.2",
+			"release": "1.el6",
+			"installdate": "1548708607",
+			"arch": "noarch"
+		},
+		"grub": {
+			"epoch": "1",
+			"version": "0.97",
+			"release": "99.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"man": {
+			"epoch": "0",
+			"version": "1.6f",
+			"release": "39.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"efibootmgr": {
+			"epoch": "0",
+			"version": "0.5.4",
+			"release": "15.el6",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"acl": {
+			"epoch": "0",
+			"version": "2.2.49",
+			"release": "7.el6_9.1",
+			"installdate": "1548708608",
+			"arch": "x86_64"
+		},
+		"rootfiles": {
+			"epoch": "0",
+			"version": "8.1",
+			"release": "6.1.el6",
+			"installdate": "1548708608",
+			"arch": "noarch"
+		}
+	},
+	"platform": "centos",
+	"platform_family": "rhel",
+	"platform_version": "6.10",
+	"root_group": "wheel",
+	"shard_seed": 46011737,
+	"shells": [
+		"/bin/sh",
+		"/bin/bash",
+		"/sbin/nologin",
+		"/bin/dash"
+	],
+	"sysconf": {
+		"LINK_MAX": 32000,
+		"_POSIX_LINK_MAX": 32000,
+		"MAX_CANON": 255,
+		"_POSIX_MAX_CANON": 255,
+		"MAX_INPUT": 255,
+		"_POSIX_MAX_INPUT": 255,
+		"NAME_MAX": 255,
+		"_POSIX_NAME_MAX": 255,
+		"PATH_MAX": 4096,
+		"_POSIX_PATH_MAX": 4096,
+		"PIPE_BUF": 4096,
+		"_POSIX_PIPE_BUF": 4096,
+		"SOCK_MAXBUF": null,
+		"_POSIX_ASYNC_IO": null,
+		"_POSIX_CHOWN_RESTRICTED": 1,
+		"_POSIX_NO_TRUNC": 1,
+		"_POSIX_PRIO_IO": null,
+		"_POSIX_SYNC_IO": null,
+		"_POSIX_VDISABLE": 0,
+		"ARG_MAX": 2621440,
+		"ATEXIT_MAX": 2147483647,
+		"CHAR_BIT": 8,
+		"CHAR_MAX": 127,
+		"CHAR_MIN": -128,
+		"CHILD_MAX": 1024,
+		"CLK_TCK": 100,
+		"INT_MAX": 2147483647,
+		"INT_MIN": -2147483648,
+		"IOV_MAX": 1024,
+		"LOGNAME_MAX": 256,
+		"LONG_BIT": 64,
+		"MB_LEN_MAX": 16,
+		"NGROUPS_MAX": 65536,
+		"NL_ARGMAX": 4096,
+		"NL_LANGMAX": 2048,
+		"NL_MSGMAX": 2147483647,
+		"NL_NMAX": 2147483647,
+		"NL_SETMAX": 2147483647,
+		"NL_TEXTMAX": 2147483647,
+		"NSS_BUFLEN_GROUP": 1024,
+		"NSS_BUFLEN_PASSWD": 1024,
+		"NZERO": 20,
+		"OPEN_MAX": 1024,
+		"PAGESIZE": 4096,
+		"PAGE_SIZE": 4096,
+		"PASS_MAX": 8192,
+		"PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+		"PTHREAD_KEYS_MAX": 1024,
+		"PTHREAD_STACK_MIN": 16384,
+		"PTHREAD_THREADS_MAX": null,
+		"SCHAR_MAX": 127,
+		"SCHAR_MIN": -128,
+		"SHRT_MAX": 32767,
+		"SHRT_MIN": -32768,
+		"SSIZE_MAX": 32767,
+		"TTY_NAME_MAX": 32,
+		"TZNAME_MAX": 6,
+		"UCHAR_MAX": 255,
+		"UINT_MAX": 4294967295,
+		"UIO_MAXIOV": 1024,
+		"ULONG_MAX": 18446744073709552000,
+		"USHRT_MAX": 65535,
+		"WORD_BIT": 32,
+		"_AVPHYS_PAGES": 174282,
+		"_NPROCESSORS_CONF": 1,
+		"_NPROCESSORS_ONLN": 1,
+		"_PHYS_PAGES": 254523,
+		"_POSIX_ARG_MAX": 2621440,
+		"_POSIX_ASYNCHRONOUS_IO": 200809,
+		"_POSIX_CHILD_MAX": 1024,
+		"_POSIX_FSYNC": 200809,
+		"_POSIX_JOB_CONTROL": 1,
+		"_POSIX_MAPPED_FILES": 200809,
+		"_POSIX_MEMLOCK": 200809,
+		"_POSIX_MEMLOCK_RANGE": 200809,
+		"_POSIX_MEMORY_PROTECTION": 200809,
+		"_POSIX_MESSAGE_PASSING": 200809,
+		"_POSIX_NGROUPS_MAX": 65536,
+		"_POSIX_OPEN_MAX": 1024,
+		"_POSIX_PII": null,
+		"_POSIX_PII_INTERNET": null,
+		"_POSIX_PII_INTERNET_DGRAM": null,
+		"_POSIX_PII_INTERNET_STREAM": null,
+		"_POSIX_PII_OSI": null,
+		"_POSIX_PII_OSI_CLTS": null,
+		"_POSIX_PII_OSI_COTS": null,
+		"_POSIX_PII_OSI_M": null,
+		"_POSIX_PII_SOCKET": null,
+		"_POSIX_PII_XTI": null,
+		"_POSIX_POLL": null,
+		"_POSIX_PRIORITIZED_IO": 200809,
+		"_POSIX_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_REALTIME_SIGNALS": 200809,
+		"_POSIX_SAVED_IDS": 1,
+		"_POSIX_SELECT": null,
+		"_POSIX_SEMAPHORES": 200809,
+		"_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+		"_POSIX_SSIZE_MAX": 32767,
+		"_POSIX_STREAM_MAX": 16,
+		"_POSIX_SYNCHRONIZED_IO": 200809,
+		"_POSIX_THREADS": 200809,
+		"_POSIX_THREAD_ATTR_STACKADDR": 200809,
+		"_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+		"_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_THREAD_PRIO_INHERIT": 200809,
+		"_POSIX_THREAD_PRIO_PROTECT": 200809,
+		"_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+		"_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+		"_POSIX_THREAD_PROCESS_SHARED": 200809,
+		"_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+		"_POSIX_TIMERS": 200809,
+		"TIMER_MAX": null,
+		"_POSIX_TZNAME_MAX": 6,
+		"_POSIX_VERSION": 200809,
+		"_T_IOV_MAX": null,
+		"_XOPEN_CRYPT": 1,
+		"_XOPEN_ENH_I18N": 1,
+		"_XOPEN_LEGACY": 1,
+		"_XOPEN_REALTIME": 1,
+		"_XOPEN_REALTIME_THREADS": 1,
+		"_XOPEN_SHM": 1,
+		"_XOPEN_UNIX": 1,
+		"_XOPEN_VERSION": 700,
+		"_XOPEN_XCU_VERSION": 4,
+		"_XOPEN_XPG2": 1,
+		"_XOPEN_XPG3": 1,
+		"_XOPEN_XPG4": 1,
+		"BC_BASE_MAX": 99,
+		"BC_DIM_MAX": 2048,
+		"BC_SCALE_MAX": 99,
+		"BC_STRING_MAX": 1000,
+		"CHARCLASS_NAME_MAX": 2048,
+		"COLL_WEIGHTS_MAX": 255,
+		"EQUIV_CLASS_MAX": null,
+		"EXPR_NEST_MAX": 32,
+		"LINE_MAX": 2048,
+		"POSIX2_BC_BASE_MAX": 99,
+		"POSIX2_BC_DIM_MAX": 2048,
+		"POSIX2_BC_SCALE_MAX": 99,
+		"POSIX2_BC_STRING_MAX": 1000,
+		"POSIX2_CHAR_TERM": 200809,
+		"POSIX2_COLL_WEIGHTS_MAX": 255,
+		"POSIX2_C_BIND": 200809,
+		"POSIX2_C_DEV": 200809,
+		"POSIX2_C_VERSION": null,
+		"POSIX2_EXPR_NEST_MAX": 32,
+		"POSIX2_FORT_DEV": null,
+		"POSIX2_FORT_RUN": null,
+		"_POSIX2_LINE_MAX": 2048,
+		"POSIX2_LINE_MAX": 2048,
+		"POSIX2_LOCALEDEF": 200809,
+		"POSIX2_RE_DUP_MAX": 32767,
+		"POSIX2_SW_DEV": 200809,
+		"POSIX2_UPE": null,
+		"POSIX2_VERSION": 200809,
+		"RE_DUP_MAX": 32767,
+		"PATH": "/bin:/usr/bin",
+		"CS_PATH": "/bin:/usr/bin",
+		"LFS_CFLAGS": null,
+		"LFS_LDFLAGS": null,
+		"LFS_LIBS": null,
+		"LFS_LINTFLAGS": null,
+		"LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+		"LFS64_LDFLAGS": null,
+		"LFS64_LIBS": null,
+		"LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+		"_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"_XBS5_ILP32_OFF32": null,
+		"XBS5_ILP32_OFF32_CFLAGS": null,
+		"XBS5_ILP32_OFF32_LDFLAGS": null,
+		"XBS5_ILP32_OFF32_LIBS": null,
+		"XBS5_ILP32_OFF32_LINTFLAGS": null,
+		"_XBS5_ILP32_OFFBIG": null,
+		"XBS5_ILP32_OFFBIG_CFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LDFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LIBS": null,
+		"XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+		"_XBS5_LP64_OFF64": 1,
+		"XBS5_LP64_OFF64_CFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LDFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LIBS": null,
+		"XBS5_LP64_OFF64_LINTFLAGS": null,
+		"_XBS5_LPBIG_OFFBIG": null,
+		"XBS5_LPBIG_OFFBIG_CFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LIBS": null,
+		"XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_ILP32_OFF32": null,
+		"POSIX_V6_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LIBS": null,
+		"POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"_POSIX_V6_ILP32_OFFBIG": null,
+		"POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_LP64_OFF64": 1,
+		"POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LIBS": null,
+		"POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V6_LPBIG_OFFBIG": null,
+		"POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_ILP32_OFF32": null,
+		"POSIX_V7_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LIBS": null,
+		"POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"_POSIX_V7_ILP32_OFFBIG": null,
+		"POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_LP64_OFF64": 1,
+		"POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LIBS": null,
+		"POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V7_LPBIG_OFFBIG": null,
+		"POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_ADVISORY_INFO": 200809,
+		"_POSIX_BARRIERS": 200809,
+		"_POSIX_BASE": null,
+		"_POSIX_C_LANG_SUPPORT": null,
+		"_POSIX_C_LANG_SUPPORT_R": null,
+		"_POSIX_CLOCK_SELECTION": 200809,
+		"_POSIX_CPUTIME": 200809,
+		"_POSIX_THREAD_CPUTIME": 200809,
+		"_POSIX_DEVICE_SPECIFIC": null,
+		"_POSIX_DEVICE_SPECIFIC_R": null,
+		"_POSIX_FD_MGMT": null,
+		"_POSIX_FIFO": null,
+		"_POSIX_PIPE": null,
+		"_POSIX_FILE_ATTRIBUTES": null,
+		"_POSIX_FILE_LOCKING": null,
+		"_POSIX_FILE_SYSTEM": null,
+		"_POSIX_MONOTONIC_CLOCK": 200809,
+		"_POSIX_MULTI_PROCESS": null,
+		"_POSIX_SINGLE_PROCESS": null,
+		"_POSIX_NETWORKING": null,
+		"_POSIX_READER_WRITER_LOCKS": 200809,
+		"_POSIX_SPIN_LOCKS": 200809,
+		"_POSIX_REGEXP": 1,
+		"_REGEX_VERSION": null,
+		"_POSIX_SHELL": 1,
+		"_POSIX_SIGNALS": null,
+		"_POSIX_SPAWN": 200809,
+		"_POSIX_SPORADIC_SERVER": null,
+		"_POSIX_THREAD_SPORADIC_SERVER": null,
+		"_POSIX_SYSTEM_DATABASE": null,
+		"_POSIX_SYSTEM_DATABASE_R": null,
+		"_POSIX_TIMEOUTS": 200809,
+		"_POSIX_TYPED_MEMORY_OBJECTS": null,
+		"_POSIX_USER_GROUPS": null,
+		"_POSIX_USER_GROUPS_R": null,
+		"POSIX2_PBS": null,
+		"POSIX2_PBS_ACCOUNTING": null,
+		"POSIX2_PBS_LOCATE": null,
+		"POSIX2_PBS_TRACK": null,
+		"POSIX2_PBS_MESSAGE": null,
+		"SYMLOOP_MAX": null,
+		"STREAM_MAX": 16,
+		"AIO_LISTIO_MAX": null,
+		"AIO_MAX": null,
+		"AIO_PRIO_DELTA_MAX": 20,
+		"DELAYTIMER_MAX": 2147483647,
+		"HOST_NAME_MAX": 64,
+		"LOGIN_NAME_MAX": 256,
+		"MQ_OPEN_MAX": null,
+		"MQ_PRIO_MAX": 32768,
+		"_POSIX_DEVICE_IO": null,
+		"_POSIX_TRACE": null,
+		"_POSIX_TRACE_EVENT_FILTER": null,
+		"_POSIX_TRACE_INHERIT": null,
+		"_POSIX_TRACE_LOG": null,
+		"RTSIG_MAX": 32,
+		"SEM_NSEMS_MAX": null,
+		"SEM_VALUE_MAX": 2147483647,
+		"SIGQUEUE_MAX": 3892,
+		"FILESIZEBITS": 64,
+		"POSIX_ALLOC_SIZE_MIN": 4096,
+		"POSIX_REC_INCR_XFER_SIZE": null,
+		"POSIX_REC_MAX_XFER_SIZE": null,
+		"POSIX_REC_MIN_XFER_SIZE": 4096,
+		"POSIX_REC_XFER_ALIGN": 4096,
+		"SYMLINK_MAX": null,
+		"GNU_LIBC_VERSION": "glibc 2.12",
+		"GNU_LIBPTHREAD_VERSION": "NPTL 2.12",
+		"POSIX2_SYMLINKS": 1,
+		"LEVEL1_ICACHE_SIZE": 32768,
+		"LEVEL1_ICACHE_ASSOC": 8,
+		"LEVEL1_ICACHE_LINESIZE": 64,
+		"LEVEL1_DCACHE_SIZE": 32768,
+		"LEVEL1_DCACHE_ASSOC": 8,
+		"LEVEL1_DCACHE_LINESIZE": 64,
+		"LEVEL2_CACHE_SIZE": 262144,
+		"LEVEL2_CACHE_ASSOC": 8,
+		"LEVEL2_CACHE_LINESIZE": 64,
+		"LEVEL3_CACHE_SIZE": 31457280,
+		"LEVEL3_CACHE_ASSOC": 20,
+		"LEVEL3_CACHE_LINESIZE": 64,
+		"LEVEL4_CACHE_SIZE": 0,
+		"LEVEL4_CACHE_ASSOC": 0,
+		"LEVEL4_CACHE_LINESIZE": 0,
+		"IPV6": 200809,
+		"RAW_SOCKETS": 200809
+	},
+	"time": {
+		"timezone": "UTC"
+	},
+	"uptime": "2 days 00 hours 41 minutes 04 seconds",
+	"uptime_seconds": 175264,
+	"virtualization": {
+		"systems": {
+			"docker": "host",
+			"xen": "guest",
+			"openstack": "host"
+		},
+		"system": "openstack",
+		"role": "host"
+	}
+}

--- a/scans/ubuntu-ec2-original.json
+++ b/scans/ubuntu-ec2-original.json
@@ -1,0 +1,4640 @@
+{
+	"block_device": {
+		"ram0": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram1": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram2": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram3": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram4": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram5": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram6": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram7": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram8": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram9": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"xvda": {
+			"size": "16777216",
+			"removable": "0",
+			"rotational": "0",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop0": {
+			"size": "186344",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop1": {
+			"size": "36744",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop2": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop3": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop4": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop5": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop6": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop7": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram10": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram11": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram12": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram13": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram14": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram15": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		}
+	},
+	"chef_packages": {
+		"ohai": {
+			"version": "14.8.10",
+			"ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/ohai-14.8.10/lib/ohai"
+		}
+	},
+	"cloud": {
+		"public_ipv4_addrs": [
+			"54.226.153.164"
+		],
+		"local_ipv4_addrs": [
+			"172.30.0.152"
+		],
+		"provider": "ec2",
+		"public_hostname": "",
+		"local_hostname": "ip-172-30-0-152.ec2.internal",
+		"public_ipv4": "54.226.153.164",
+		"local_ipv4": "172.30.0.152"
+	},
+	"command": {
+		"ps": "ps -ef"
+	},
+	"counters": {
+		"network": {
+			"interfaces": {
+				"lo": {
+					"tx": {
+						"queuelen": "1",
+						"bytes": "14456",
+						"packets": "192",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "14456",
+						"packets": "192",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				},
+				"eth0": {
+					"tx": {
+						"queuelen": "1000",
+						"bytes": "2366948",
+						"packets": "18157",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "32531548",
+						"packets": "27002",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				}
+			}
+		}
+	},
+	"cpu": {
+		"0": {
+			"vendor_id": "GenuineIntel",
+			"family": "6",
+			"model": "63",
+			"model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+			"stepping": "2",
+			"mhz": "2400.088",
+			"cache_size": "30720 KB",
+			"physical_id": "0",
+			"core_id": "0",
+			"cores": "1",
+			"flags": [
+				"fpu",
+				"vme",
+				"de",
+				"pse",
+				"tsc",
+				"msr",
+				"pae",
+				"mce",
+				"cx8",
+				"apic",
+				"sep",
+				"mtrr",
+				"pge",
+				"mca",
+				"cmov",
+				"pat",
+				"pse36",
+				"clflush",
+				"mmx",
+				"fxsr",
+				"sse",
+				"sse2",
+				"ht",
+				"syscall",
+				"nx",
+				"rdtscp",
+				"lm",
+				"constant_tsc",
+				"rep_good",
+				"nopl",
+				"xtopology",
+				"pni",
+				"pclmulqdq",
+				"ssse3",
+				"fma",
+				"cx16",
+				"pcid",
+				"sse4_1",
+				"sse4_2",
+				"x2apic",
+				"movbe",
+				"popcnt",
+				"tsc_deadline_timer",
+				"aes",
+				"xsave",
+				"avx",
+				"f16c",
+				"rdrand",
+				"hypervisor",
+				"lahf_lm",
+				"abm",
+				"invpcid_single",
+				"kaiser",
+				"fsgsbase",
+				"bmi1",
+				"avx2",
+				"smep",
+				"bmi2",
+				"erms",
+				"invpcid",
+				"xsaveopt"
+			]
+		},
+		"total": 1,
+		"real": 1,
+		"cores": 1
+	},
+	"current_user": "ubuntu",
+	"dmi": {
+		"dmidecode_version": "3.0"
+	},
+	"domain": null,
+	"ec2": {
+		"ami_id": "ami-0565af6e282977273",
+		"ami_launch_index": "0",
+		"ami_manifest_path": "(unknown)",
+		"block_device_mapping_ami": "/dev/sda1",
+		"block_device_mapping_root": "/dev/sda1",
+		"hostname": "ip-172-30-0-152.ec2.internal",
+		"instance_action": "none",
+		"instance_id": "i-0e520d7d9edafbe68",
+		"instance_type": "t2.micro",
+		"local_hostname": "ip-172-30-0-152.ec2.internal",
+		"local_ipv4": "172.30.0.152",
+		"mac": "0a:a3:fe:6c:de:9e",
+		"metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+		"network_interfaces_macs": {
+			"0a:a3:fe:6c:de:9e": {
+				"device_number": "0",
+				"interface_id": "eni-02654d490c2488e34",
+				"ipv4-associations": {
+					"54.226.153.164": "172.30.0.152"
+				},
+				"local_hostname": "ip-172-30-0-152.ec2.internal",
+				"local_ipv4s": "172.30.0.152",
+				"mac": "0a:a3:fe:6c:de:9e",
+				"owner_id": "399524901138",
+				"public_hostname": "",
+				"public_ipv4s": "54.226.153.164",
+				"security_group_ids": "sg-c7086ca3",
+				"security_groups": "launch-wizard-1",
+				"subnet_id": "subnet-49b5d63e",
+				"subnet_ipv4_cidr_block": "172.30.0.0/24",
+				"vpc_id": "vpc-02550367",
+				"vpc_ipv4_cidr_block": "172.30.0.0/16",
+				"vpc_ipv4_cidr_blocks": "172.30.0.0/16"
+			}
+		},
+		"placement_availability_zone": "us-east-1a",
+		"profile": "default-hvm",
+		"public_hostname": "",
+		"public_ipv4": "54.226.153.164",
+		"public_keys_0_openssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiezJPkkl7W6lXMfl3x7oEs6ahrR8W35zLGxQRsnq99ShKpZnB+X20wlskUQt8PpXE+3rersJwA8euF5lTiml53K/ojM190FZAiwgvYjLe0yB/mtP8nPzh5h2G6U6Iu7eNV0C2f+rzvzy7LM8W6t8ULpS+W48Va2teVD7927BMwWVzL1g4iLRvRnOHpYkVlO9KbzUzO2mDW8giT8tRQyc7hDBiJClLxxr+hUu7i/8Rfq2esTp2aXRyvpVycfExTKGotVcLYd4+f3VH2Lmf4mR5SckGXGyym/VUOl6uaRDoTijTaf3DDL3sZiZBTEdihGidt3hlysbum2HfWKfxbGgr ohai\n",
+		"reservation_id": "r-07399c1aa037f694e",
+		"security_groups": [
+			"launch-wizard-1"
+		],
+		"services_domain": "amazonaws.com",
+		"services_partition": "aws",
+		"userdata": null,
+		"account_id": "399524901138",
+		"availability_zone": "us-east-1a",
+		"region": "us-east-1"
+	},
+	"etc": {
+		"passwd": {
+			"root": {
+				"dir": "/root",
+				"gid": 0,
+				"uid": 0,
+				"shell": "/bin/bash",
+				"gecos": "root"
+			},
+			"daemon": {
+				"dir": "/usr/sbin",
+				"gid": 1,
+				"uid": 1,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "daemon"
+			},
+			"bin": {
+				"dir": "/bin",
+				"gid": 2,
+				"uid": 2,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "bin"
+			},
+			"sys": {
+				"dir": "/dev",
+				"gid": 3,
+				"uid": 3,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "sys"
+			},
+			"sync": {
+				"dir": "/bin",
+				"gid": 65534,
+				"uid": 4,
+				"shell": "/bin/sync",
+				"gecos": "sync"
+			},
+			"games": {
+				"dir": "/usr/games",
+				"gid": 60,
+				"uid": 5,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "games"
+			},
+			"man": {
+				"dir": "/var/cache/man",
+				"gid": 12,
+				"uid": 6,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "man"
+			},
+			"lp": {
+				"dir": "/var/spool/lpd",
+				"gid": 7,
+				"uid": 7,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "lp"
+			},
+			"mail": {
+				"dir": "/var/mail",
+				"gid": 8,
+				"uid": 8,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "mail"
+			},
+			"news": {
+				"dir": "/var/spool/news",
+				"gid": 9,
+				"uid": 9,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "news"
+			},
+			"uucp": {
+				"dir": "/var/spool/uucp",
+				"gid": 10,
+				"uid": 10,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "uucp"
+			},
+			"proxy": {
+				"dir": "/bin",
+				"gid": 13,
+				"uid": 13,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "proxy"
+			},
+			"www-data": {
+				"dir": "/var/www",
+				"gid": 33,
+				"uid": 33,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "www-data"
+			},
+			"backup": {
+				"dir": "/var/backups",
+				"gid": 34,
+				"uid": 34,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "backup"
+			},
+			"list": {
+				"dir": "/var/list",
+				"gid": 38,
+				"uid": 38,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "Mailing List Manager"
+			},
+			"irc": {
+				"dir": "/var/run/ircd",
+				"gid": 39,
+				"uid": 39,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "ircd"
+			},
+			"gnats": {
+				"dir": "/var/lib/gnats",
+				"gid": 41,
+				"uid": 41,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "Gnats Bug-Reporting System (admin)"
+			},
+			"nobody": {
+				"dir": "/nonexistent",
+				"gid": 65534,
+				"uid": 65534,
+				"shell": "/usr/sbin/nologin",
+				"gecos": "nobody"
+			},
+			"systemd-timesync": {
+				"dir": "/run/systemd",
+				"gid": 102,
+				"uid": 100,
+				"shell": "/bin/false",
+				"gecos": "systemd Time Synchronization,,,"
+			},
+			"systemd-network": {
+				"dir": "/run/systemd/netif",
+				"gid": 103,
+				"uid": 101,
+				"shell": "/bin/false",
+				"gecos": "systemd Network Management,,,"
+			},
+			"systemd-resolve": {
+				"dir": "/run/systemd/resolve",
+				"gid": 104,
+				"uid": 102,
+				"shell": "/bin/false",
+				"gecos": "systemd Resolver,,,"
+			},
+			"systemd-bus-proxy": {
+				"dir": "/run/systemd",
+				"gid": 105,
+				"uid": 103,
+				"shell": "/bin/false",
+				"gecos": "systemd Bus Proxy,,,"
+			},
+			"syslog": {
+				"dir": "/home/syslog",
+				"gid": 108,
+				"uid": 104,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"_apt": {
+				"dir": "/nonexistent",
+				"gid": 65534,
+				"uid": 105,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"lxd": {
+				"dir": "/var/lib/lxd/",
+				"gid": 65534,
+				"uid": 106,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"messagebus": {
+				"dir": "/var/run/dbus",
+				"gid": 111,
+				"uid": 107,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"uuidd": {
+				"dir": "/run/uuidd",
+				"gid": 112,
+				"uid": 108,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"dnsmasq": {
+				"dir": "/var/lib/misc",
+				"gid": 65534,
+				"uid": 109,
+				"shell": "/bin/false",
+				"gecos": "dnsmasq,,,"
+			},
+			"sshd": {
+				"dir": "/var/run/sshd",
+				"gid": 65534,
+				"uid": 110,
+				"shell": "/usr/sbin/nologin",
+				"gecos": ""
+			},
+			"pollinate": {
+				"dir": "/var/cache/pollinate",
+				"gid": 1,
+				"uid": 111,
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"ubuntu": {
+				"dir": "/home/ubuntu",
+				"gid": 1000,
+				"uid": 1000,
+				"shell": "/bin/bash",
+				"gecos": "Ubuntu"
+			}
+		},
+		"group": {
+			"root": {
+				"gid": 0,
+				"members": []
+			},
+			"daemon": {
+				"gid": 1,
+				"members": []
+			},
+			"bin": {
+				"gid": 2,
+				"members": []
+			},
+			"sys": {
+				"gid": 3,
+				"members": []
+			},
+			"adm": {
+				"gid": 4,
+				"members": [
+					"syslog",
+					"ubuntu"
+				]
+			},
+			"tty": {
+				"gid": 5,
+				"members": []
+			},
+			"disk": {
+				"gid": 6,
+				"members": []
+			},
+			"lp": {
+				"gid": 7,
+				"members": []
+			},
+			"mail": {
+				"gid": 8,
+				"members": []
+			},
+			"news": {
+				"gid": 9,
+				"members": []
+			},
+			"uucp": {
+				"gid": 10,
+				"members": []
+			},
+			"man": {
+				"gid": 12,
+				"members": []
+			},
+			"proxy": {
+				"gid": 13,
+				"members": []
+			},
+			"kmem": {
+				"gid": 15,
+				"members": []
+			},
+			"dialout": {
+				"gid": 20,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"fax": {
+				"gid": 21,
+				"members": []
+			},
+			"voice": {
+				"gid": 22,
+				"members": []
+			},
+			"cdrom": {
+				"gid": 24,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"floppy": {
+				"gid": 25,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"tape": {
+				"gid": 26,
+				"members": []
+			},
+			"sudo": {
+				"gid": 27,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"audio": {
+				"gid": 29,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"dip": {
+				"gid": 30,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"www-data": {
+				"gid": 33,
+				"members": []
+			},
+			"backup": {
+				"gid": 34,
+				"members": []
+			},
+			"operator": {
+				"gid": 37,
+				"members": []
+			},
+			"list": {
+				"gid": 38,
+				"members": []
+			},
+			"irc": {
+				"gid": 39,
+				"members": []
+			},
+			"src": {
+				"gid": 40,
+				"members": []
+			},
+			"gnats": {
+				"gid": 41,
+				"members": []
+			},
+			"shadow": {
+				"gid": 42,
+				"members": []
+			},
+			"utmp": {
+				"gid": 43,
+				"members": []
+			},
+			"video": {
+				"gid": 44,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"sasl": {
+				"gid": 45,
+				"members": []
+			},
+			"plugdev": {
+				"gid": 46,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"staff": {
+				"gid": 50,
+				"members": []
+			},
+			"games": {
+				"gid": 60,
+				"members": []
+			},
+			"users": {
+				"gid": 100,
+				"members": []
+			},
+			"nogroup": {
+				"gid": 65534,
+				"members": []
+			},
+			"systemd-journal": {
+				"gid": 101,
+				"members": []
+			},
+			"systemd-timesync": {
+				"gid": 102,
+				"members": []
+			},
+			"systemd-network": {
+				"gid": 103,
+				"members": []
+			},
+			"systemd-resolve": {
+				"gid": 104,
+				"members": []
+			},
+			"systemd-bus-proxy": {
+				"gid": 105,
+				"members": []
+			},
+			"input": {
+				"gid": 106,
+				"members": []
+			},
+			"crontab": {
+				"gid": 107,
+				"members": []
+			},
+			"syslog": {
+				"gid": 108,
+				"members": []
+			},
+			"netdev": {
+				"gid": 109,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"lxd": {
+				"gid": 110,
+				"members": [
+					"ubuntu"
+				]
+			},
+			"messagebus": {
+				"gid": 111,
+				"members": []
+			},
+			"uuidd": {
+				"gid": 112,
+				"members": []
+			},
+			"ssh": {
+				"gid": 113,
+				"members": []
+			},
+			"mlocate": {
+				"gid": 114,
+				"members": []
+			},
+			"admin": {
+				"gid": 115,
+				"members": []
+			},
+			"ubuntu": {
+				"gid": 1000,
+				"members": []
+			}
+		}
+	},
+	"filesystem": {
+		"by_device": {
+			"udev": {
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				],
+				"mounts": [
+					"/dev"
+				]
+			},
+			"tmpfs": {
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				],
+				"mounts": [
+					"/run",
+					"/dev/shm",
+					"/run/lock",
+					"/sys/fs/cgroup",
+					"/run/user/1000"
+				]
+			},
+			"/dev/xvda1": {
+				"kb_size": "8065444",
+				"kb_used": "1154108",
+				"kb_available": "6894952",
+				"percent_used": "15%",
+				"total_inodes": "1024000",
+				"inodes_used": "73355",
+				"inodes_available": "950645",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs",
+				"mounts": [
+					"/"
+				]
+			},
+			"/dev/loop0": {
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"mounts": [
+					"/snap/core/6350"
+				]
+			},
+			"/dev/loop1": {
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"mounts": [
+					"/snap/amazon-ssm-agent/930"
+				]
+			},
+			"sysfs": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys"
+				]
+			},
+			"proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/proc"
+				]
+			},
+			"devpts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				],
+				"mounts": [
+					"/dev/pts"
+				]
+			},
+			"securityfs": {
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/kernel/security"
+				]
+			},
+			"cgroup": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				],
+				"mounts": [
+					"/sys/fs/cgroup/systemd",
+					"/sys/fs/cgroup/blkio",
+					"/sys/fs/cgroup/devices",
+					"/sys/fs/cgroup/net_cls,net_prio",
+					"/sys/fs/cgroup/cpuset",
+					"/sys/fs/cgroup/freezer",
+					"/sys/fs/cgroup/cpu,cpuacct",
+					"/sys/fs/cgroup/perf_event",
+					"/sys/fs/cgroup/pids",
+					"/sys/fs/cgroup/memory",
+					"/sys/fs/cgroup/hugetlb"
+				]
+			},
+			"pstore": {
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/fs/pstore"
+				]
+			},
+			"systemd-1": {
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				],
+				"mounts": [
+					"/proc/sys/fs/binfmt_misc"
+				]
+			},
+			"hugetlbfs": {
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/dev/hugepages"
+				]
+			},
+			"mqueue": {
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/dev/mqueue"
+				]
+			},
+			"debugfs": {
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/kernel/debug"
+				]
+			},
+			"fusectl": {
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/fs/fuse/connections"
+				]
+			},
+			"lxcfs": {
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				],
+				"mounts": [
+					"/var/lib/lxcfs"
+				]
+			},
+			"/var/lib/snapd/snaps/core_6350.snap": {
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				],
+				"mounts": [
+					"/snap/core/6350"
+				]
+			},
+			"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap": {
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				],
+				"mounts": [
+					"/snap/amazon-ssm-agent/930"
+				]
+			},
+			"/dev/xvda": {
+				"mounts": []
+			}
+		},
+		"by_mountpoint": {
+			"/dev": {
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				],
+				"devices": [
+					"udev"
+				]
+			},
+			"/run": {
+				"kb_size": "101444",
+				"kb_used": "3320",
+				"kb_available": "98124",
+				"percent_used": "4%",
+				"total_inodes": "126804",
+				"inodes_used": "413",
+				"inodes_available": "126391",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"size=101444k",
+					"mode=755"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/": {
+				"kb_size": "8065444",
+				"kb_used": "1154108",
+				"kb_available": "6894952",
+				"percent_used": "15%",
+				"total_inodes": "1024000",
+				"inodes_used": "73355",
+				"inodes_available": "950645",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs",
+				"devices": [
+					"/dev/xvda1"
+				]
+			},
+			"/dev/shm": {
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "1",
+				"inodes_available": "126803",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/run/lock": {
+				"kb_size": "5120",
+				"kb_used": "0",
+				"kb_available": "5120",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "3",
+				"inodes_available": "126801",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"size=5120k"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/sys/fs/cgroup": {
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "16",
+				"inodes_available": "126788",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"ro",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"mode=755"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/run/user/1000": {
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/snap/core/6350": {
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"devices": [
+					"/dev/loop0",
+					"/var/lib/snapd/snaps/core_6350.snap"
+				],
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/snap/amazon-ssm-agent/930": {
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"devices": [
+					"/dev/loop1",
+					"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap"
+				],
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/sys": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"sysfs"
+				]
+			},
+			"/proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"proc"
+				]
+			},
+			"/dev/pts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				],
+				"devices": [
+					"devpts"
+				]
+			},
+			"/sys/kernel/security": {
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"securityfs"
+				]
+			},
+			"/sys/fs/cgroup/systemd": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"xattr",
+					"release_agent=/lib/systemd/systemd-cgroups-agent",
+					"name=systemd"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/pstore": {
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"pstore"
+				]
+			},
+			"/sys/fs/cgroup/blkio": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"blkio"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/devices": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"devices"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/net_cls,net_prio": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"net_cls",
+					"net_prio"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/cpuset": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpuset"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/freezer": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"freezer"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/cpu,cpuacct": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpu",
+					"cpuacct"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/perf_event": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"perf_event"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/pids": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"pids"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/memory": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"memory"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/hugetlb": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/proc/sys/fs/binfmt_misc": {
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				],
+				"devices": [
+					"systemd-1"
+				]
+			},
+			"/dev/hugepages": {
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"hugetlbfs"
+				]
+			},
+			"/dev/mqueue": {
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"mqueue"
+				]
+			},
+			"/sys/kernel/debug": {
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"debugfs"
+				]
+			},
+			"/sys/fs/fuse/connections": {
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"fusectl"
+				]
+			},
+			"/var/lib/lxcfs": {
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				],
+				"devices": [
+					"lxcfs"
+				]
+			}
+		},
+		"by_pair": {
+			"udev,/dev": {
+				"device": "udev",
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"mount": "/dev",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				]
+			},
+			"tmpfs,/run": {
+				"device": "tmpfs",
+				"kb_size": "101444",
+				"kb_used": "3320",
+				"kb_available": "98124",
+				"percent_used": "4%",
+				"mount": "/run",
+				"total_inodes": "126804",
+				"inodes_used": "413",
+				"inodes_available": "126391",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"size=101444k",
+					"mode=755"
+				]
+			},
+			"/dev/xvda1,/": {
+				"device": "/dev/xvda1",
+				"kb_size": "8065444",
+				"kb_used": "1154108",
+				"kb_available": "6894952",
+				"percent_used": "15%",
+				"mount": "/",
+				"total_inodes": "1024000",
+				"inodes_used": "73355",
+				"inodes_available": "950645",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs"
+			},
+			"tmpfs,/dev/shm": {
+				"device": "tmpfs",
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"mount": "/dev/shm",
+				"total_inodes": "126804",
+				"inodes_used": "1",
+				"inodes_available": "126803",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev"
+				]
+			},
+			"tmpfs,/run/lock": {
+				"device": "tmpfs",
+				"kb_size": "5120",
+				"kb_used": "0",
+				"kb_available": "5120",
+				"percent_used": "0%",
+				"mount": "/run/lock",
+				"total_inodes": "126804",
+				"inodes_used": "3",
+				"inodes_available": "126801",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"size=5120k"
+				]
+			},
+			"tmpfs,/sys/fs/cgroup": {
+				"device": "tmpfs",
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"mount": "/sys/fs/cgroup",
+				"total_inodes": "126804",
+				"inodes_used": "16",
+				"inodes_available": "126788",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"ro",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"mode=755"
+				]
+			},
+			"tmpfs,/run/user/1000": {
+				"device": "tmpfs",
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"mount": "/run/user/1000",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				]
+			},
+			"/dev/loop0,/snap/core/6350": {
+				"device": "/dev/loop0",
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"mount": "/snap/core/6350",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs"
+			},
+			"/dev/loop1,/snap/amazon-ssm-agent/930": {
+				"device": "/dev/loop1",
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"mount": "/snap/amazon-ssm-agent/930",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs"
+			},
+			"sysfs,/sys": {
+				"device": "sysfs",
+				"mount": "/sys",
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"proc,/proc": {
+				"device": "proc",
+				"mount": "/proc",
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"devpts,/dev/pts": {
+				"device": "devpts",
+				"mount": "/dev/pts",
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				]
+			},
+			"securityfs,/sys/kernel/security": {
+				"device": "securityfs",
+				"mount": "/sys/kernel/security",
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/systemd": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/systemd",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"xattr",
+					"release_agent=/lib/systemd/systemd-cgroups-agent",
+					"name=systemd"
+				]
+			},
+			"pstore,/sys/fs/pstore": {
+				"device": "pstore",
+				"mount": "/sys/fs/pstore",
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/blkio": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/blkio",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"blkio"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/devices": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/devices",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"devices"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/net_cls,net_prio",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"net_cls",
+					"net_prio"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/cpuset": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/cpuset",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpuset"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/freezer": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/freezer",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"freezer"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/cpu,cpuacct",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpu",
+					"cpuacct"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/perf_event": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/perf_event",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"perf_event"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/pids": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/pids",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"pids"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/memory": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/memory",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"memory"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/hugetlb": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/hugetlb",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				]
+			},
+			"systemd-1,/proc/sys/fs/binfmt_misc": {
+				"device": "systemd-1",
+				"mount": "/proc/sys/fs/binfmt_misc",
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				]
+			},
+			"hugetlbfs,/dev/hugepages": {
+				"device": "hugetlbfs",
+				"mount": "/dev/hugepages",
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"mqueue,/dev/mqueue": {
+				"device": "mqueue",
+				"mount": "/dev/mqueue",
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"debugfs,/sys/kernel/debug": {
+				"device": "debugfs",
+				"mount": "/sys/kernel/debug",
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"fusectl,/sys/fs/fuse/connections": {
+				"device": "fusectl",
+				"mount": "/sys/fs/fuse/connections",
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"lxcfs,/var/lib/lxcfs": {
+				"device": "lxcfs",
+				"mount": "/var/lib/lxcfs",
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				]
+			},
+			"/var/lib/snapd/snaps/core_6350.snap,/snap/core/6350": {
+				"device": "/var/lib/snapd/snaps/core_6350.snap",
+				"mount": "/snap/core/6350",
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap,/snap/amazon-ssm-agent/930": {
+				"device": "/var/lib/snapd/snaps/amazon-ssm-agent_930.snap",
+				"mount": "/snap/amazon-ssm-agent/930",
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/dev/xvda,": {
+				"device": "/dev/xvda"
+			}
+		}
+	},
+	"fips": {
+		"kernel": {
+			"enabled": false
+		}
+	},
+	"hostname": "ip-172-30-0-152",
+	"hostnamectl": {
+		"static_hostname": "ip-172-30-0-152",
+		"icon_name": "computer-vm",
+		"chassis": "vm",
+		"machine_id": "369e1d700cb1486188eadb9969d1346b",
+		"boot_id": "9022ea316a854156bb86929f079aa2b2",
+		"virtualization": "xen",
+		"operating_system": "Ubuntu 16.04.5 LTS",
+		"kernel": "Linux 4.4.0-1075-aws",
+		"architecture": "x86-64"
+	},
+	"idletime": "30 seconds",
+	"idletime_seconds": 30,
+	"init_package": "systemd",
+	"ip6address": "fe80::8a3:feff:fe6c:de9e",
+	"ipaddress": "172.30.0.152",
+	"json?": "{\n  \"devpayProductCodes\" : null,\n  \"marketplaceProductCodes\" : null,\n  \"version\" : \"2017-09-30\",\n  \"instanceType\" : \"t2.micro\",\n  \"billingProducts\" : null,\n  \"instanceId\" : \"i-0e520d7d9edafbe68\",\n  \"pendingTime\" : \"2019-04-04T04:17:27Z\",\n  \"imageId\" : \"ami-0565af6e282977273\",\n  \"accountId\" : \"399524901138\",\n  \"availabilityZone\" : \"us-east-1a\",\n  \"kernelId\" : null,\n  \"ramdiskId\" : null,\n  \"architecture\" : \"x86_64\",\n  \"privateIp\" : \"172.30.0.152\",\n  \"region\" : \"us-east-1\"\n}",
+	"kernel": {
+		"name": "Linux",
+		"release": "4.4.0-1075-aws",
+		"version": "#85-Ubuntu SMP Thu Jan 17 17:15:12 UTC 2019",
+		"machine": "x86_64",
+		"processor": "x86_64",
+		"os": "GNU/Linux",
+		"modules": {
+			"serio_raw": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"ib_iser": {
+				"size": "49152",
+				"refcount": "0",
+				"version": "1.6"
+			},
+			"rdma_cm": {
+				"size": "49152",
+				"refcount": "1"
+			},
+			"iw_cm": {
+				"size": "45056",
+				"refcount": "1"
+			},
+			"ib_cm": {
+				"size": "49152",
+				"refcount": "1"
+			},
+			"ib_sa": {
+				"size": "36864",
+				"refcount": "2"
+			},
+			"ib_mad": {
+				"size": "49152",
+				"refcount": "2"
+			},
+			"ib_core": {
+				"size": "106496",
+				"refcount": "6"
+			},
+			"ib_addr": {
+				"size": "20480",
+				"refcount": "2"
+			},
+			"iscsi_tcp": {
+				"size": "20480",
+				"refcount": "0"
+			},
+			"libiscsi_tcp": {
+				"size": "24576",
+				"refcount": "1"
+			},
+			"libiscsi": {
+				"size": "53248",
+				"refcount": "3"
+			},
+			"scsi_transport_iscsi": {
+				"size": "102400",
+				"refcount": "4",
+				"version": "2.0-870"
+			},
+			"autofs4": {
+				"size": "40960",
+				"refcount": "2"
+			},
+			"btrfs": {
+				"size": "987136",
+				"refcount": "0"
+			},
+			"raid10": {
+				"size": "49152",
+				"refcount": "0"
+			},
+			"raid456": {
+				"size": "106496",
+				"refcount": "0"
+			},
+			"async_raid6_recov": {
+				"size": "20480",
+				"refcount": "1"
+			},
+			"async_memcpy": {
+				"size": "16384",
+				"refcount": "2"
+			},
+			"async_pq": {
+				"size": "16384",
+				"refcount": "2"
+			},
+			"async_xor": {
+				"size": "16384",
+				"refcount": "3"
+			},
+			"async_tx": {
+				"size": "16384",
+				"refcount": "5"
+			},
+			"xor": {
+				"size": "24576",
+				"refcount": "2"
+			},
+			"raid6_pq": {
+				"size": "102400",
+				"refcount": "4"
+			},
+			"libcrc32c": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"raid1": {
+				"size": "40960",
+				"refcount": "0"
+			},
+			"raid0": {
+				"size": "20480",
+				"refcount": "0"
+			},
+			"multipath": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"linear": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"crct10dif_pclmul": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"crc32_pclmul": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"ghash_clmulni_intel": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"aesni_intel": {
+				"size": "167936",
+				"refcount": "0"
+			},
+			"aes_x86_64": {
+				"size": "20480",
+				"refcount": "1"
+			},
+			"lrw": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"gf128mul": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"glue_helper": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"ablk_helper": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"cryptd": {
+				"size": "20480",
+				"refcount": "3"
+			}
+		}
+	},
+	"keys": {
+		"ssh": {
+			"host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC46AW9jrw6x3zRaWyd2+kj9173D4Xy0+PI/yGuR1Ca3hnFBusomDfjhKGT5WPJXgHQ2lO1t3nwRRjVeMDxJTyTqs/c0VRZCnXf99sQg8a9uHQQ0oX+3KDa0+OQqTEYvQVOmXx3227CBbEIJ7+YERAd0XDrtz8qTwc68x8m1NgMe3O9jYXu8hZIkBa5Sc1XrvRxjQe7gsBGsXRlgE5J7Esp5RuWjIxmDLU0qn24BGcN5tm8pI7tBPAjUi2Mwl7EtTsyHfd1hNVTmlFFg3cS7O1asKH4O5OTYFAB5NNxt9mK711sBFUM18iLn/52E80aWdG1MBszeoM4/m0hdSFg71QN",
+			"host_dsa_public": "AAAAB3NzaC1kc3MAAACBAP2NAZor8gVkt9B/uO4mDeBHU1tfxfLSOurUrsy+SZMEB9/W+Q2fFs647GH85uGjVcxUOXslje+27Ty54Pd8YRXFuBiMejHn67SQFu1Djjg6r3GNv91URZtivUQT8CF3n/iu4QBnFFcD6wcjo1JCHzj+3Ha3D/LrrQVuVk+KqluJAAAAFQDOLL5zcwhXV4bGeNIXlamBEE8AdwAAAIAQ2Qi3Ln163kIsYDHIjjvkQMgDhw4LiaGLKwZcJHM80PZmxQxo+l7owrWC4xQYL75Bm9s/gqomI8A+AeiwyvpXlMufFhSnIoD8tX9pPcuRbCu500P/PBSNvno1k8FETUIAQRI/P6zK+2msWM2+sAmXMKsQl96/jo/101HBsDrGfwAAAIEA97sEFMn2uUUxVyMp/kfgkkrdVRksBqRi/va2H6lZqWbbW/RCbBWkCrPVqAH3Ss6uUQm8CX9kSo9E8rJ5Apb5hNRdJFBE/PiIQo6a4sFNnx+aRc2SrFTqs6wPgnkQSMBpL0aaUNuJ29pNJ5+fWRfAJ+dubpkljY1zXZLXGm7QEY0=",
+			"host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL4w6eOLaCOjNJxP+iYePhKKqHi9rII57PjvVtrA5Ps/8ADdHcU7D1SkDLjr+go0LjgP4OBK8KxnV0x4VFI9neA=",
+			"host_ecdsa_type": "ecdsa-sha2-nistp256",
+			"host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIKk3Bqtw/Q1/9Ra90cSX5KL4hEUK3Pw0zpWyVH2HzUd1"
+		}
+	},
+	"languages": {
+		"perl": {
+			"version": "5.22.1",
+			"archname": "x86_64-linux-gnu-thread-multi"
+		},
+		"ruby": {}
+	},
+	"lsb": {
+		"id": "Ubuntu",
+		"description": "Ubuntu 16.04.5 LTS",
+		"release": "16.04",
+		"codename": "xenial"
+	},
+	"macaddress": "0A:A3:FE:6C:DE:9E",
+	"machine_id": "369e1d700cb1486188eadb9969d1346b",
+	"machinename": "ip-172-30-0-152",
+	"memory": {
+		"swap": {
+			"cached": "0kB",
+			"total": "0kB",
+			"free": "0kB"
+		},
+		"hugepages": {
+			"total": "0",
+			"free": "0",
+			"reserved": "0",
+			"surplus": "0"
+		},
+		"total": "1014436kB",
+		"free": "296620kB",
+		"available": "754164kB",
+		"buffers": "43028kB",
+		"cached": "521324kB",
+		"active": "201280kB",
+		"inactive": "415324kB",
+		"dirty": "14232kB",
+		"writeback": "0kB",
+		"anon_pages": "55900kB",
+		"mapped": "51964kB",
+		"slab": "74232kB",
+		"slab_reclaimable": "53356kB",
+		"slab_unreclaim": "20876kB",
+		"page_tables": "3240kB",
+		"nfs_unstable": "0kB",
+		"bounce": "0kB",
+		"commit_limit": "507216kB",
+		"committed_as": "316016kB",
+		"vmalloc_total": "34359738367kB",
+		"vmalloc_used": "0kB",
+		"vmalloc_chunk": "0kB",
+		"hugepage_size": "2048kB"
+	},
+	"network": {
+		"interfaces": {
+			"lo": {
+				"mtu": "65536",
+				"flags": [
+					"LOOPBACK",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Loopback",
+				"addresses": {
+					"127.0.0.1": {
+						"family": "inet",
+						"prefixlen": "8",
+						"netmask": "255.0.0.0",
+						"scope": "Node"
+					},
+					"::1": {
+						"family": "inet6",
+						"prefixlen": "128",
+						"scope": "Node",
+						"tags": []
+					}
+				},
+				"state": "unknown"
+			},
+			"eth0": {
+				"type": "eth",
+				"number": "0",
+				"mtu": "9001",
+				"flags": [
+					"BROADCAST",
+					"MULTICAST",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Ethernet",
+				"addresses": {
+					"0A:A3:FE:6C:DE:9E": {
+						"family": "lladdr"
+					},
+					"172.30.0.152": {
+						"family": "inet",
+						"prefixlen": "24",
+						"netmask": "255.255.255.0",
+						"broadcast": "172.30.0.255",
+						"scope": "Global"
+					},
+					"fe80::8a3:feff:fe6c:de9e": {
+						"family": "inet6",
+						"prefixlen": "64",
+						"scope": "Link",
+						"tags": []
+					}
+				},
+				"state": "up",
+				"arp": {
+					"172.30.0.1": "0a:e7:37:d9:20:26",
+					"172.30.0.2": "0a:e7:37:d9:20:26"
+				},
+				"routes": [
+					{
+						"destination": "default",
+						"family": "inet",
+						"via": "172.30.0.1"
+					},
+					{
+						"destination": "172.30.0.0/24",
+						"family": "inet",
+						"scope": "link",
+						"proto": "kernel",
+						"src": "172.30.0.152"
+					},
+					{
+						"destination": "fe80::/64",
+						"family": "inet6",
+						"metric": "256",
+						"proto": "kernel"
+					}
+				],
+				"ring_params": {}
+			}
+		},
+		"default_interface": "eth0",
+		"default_gateway": "172.30.0.1"
+	},
+	"ohai_time": 1554351534.357953,
+	"os": "linux",
+	"os_version": "4.4.0-1075-aws",
+	"packages": {
+		"accountsservice": {
+			"version": "0.6.40-2ubuntu11.3",
+			"arch": "amd64"
+		},
+		"acl": {
+			"version": "2.2.52-3",
+			"arch": "amd64"
+		},
+		"acpid": {
+			"version": "1:2.0.26-1ubuntu2",
+			"arch": "amd64"
+		},
+		"adduser": {
+			"version": "3.113+nmu3ubuntu4",
+			"arch": "all"
+		},
+		"apparmor": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"apport": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"apport-symptoms": {
+			"version": "0.20",
+			"arch": "all"
+		},
+		"apt": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"apt-transport-https": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"apt-utils": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"at": {
+			"version": "3.1.18-2ubuntu1",
+			"arch": "amd64"
+		},
+		"base-files": {
+			"version": "9.4ubuntu4.7",
+			"arch": "amd64"
+		},
+		"base-passwd": {
+			"version": "3.5.39",
+			"arch": "amd64"
+		},
+		"bash": {
+			"version": "4.3-14ubuntu1.2",
+			"arch": "amd64"
+		},
+		"bash-completion": {
+			"version": "1:2.1-4.2ubuntu1.1",
+			"arch": "all"
+		},
+		"bcache-tools": {
+			"version": "1.0.8-2",
+			"arch": "amd64"
+		},
+		"bind9-host": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"bsdmainutils": {
+			"version": "9.0.6ubuntu3",
+			"arch": "amd64"
+		},
+		"bsdutils": {
+			"version": "1:2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"btrfs-tools": {
+			"version": "4.4-1ubuntu1",
+			"arch": "amd64"
+		},
+		"busybox-initramfs": {
+			"version": "1:1.22.0-15ubuntu1",
+			"arch": "amd64"
+		},
+		"busybox-static": {
+			"version": "1:1.22.0-15ubuntu1",
+			"arch": "amd64"
+		},
+		"byobu": {
+			"version": "5.106-0ubuntu1",
+			"arch": "all"
+		},
+		"bzip2": {
+			"version": "1.0.6-8",
+			"arch": "amd64"
+		},
+		"ca-certificates": {
+			"version": "20170717~16.04.2",
+			"arch": "all"
+		},
+		"chef": {
+			"version": "14.11.21-1",
+			"arch": "amd64"
+		},
+		"cloud-guest-utils": {
+			"version": "0.27-0ubuntu25.1",
+			"arch": "all"
+		},
+		"cloud-init": {
+			"version": "18.4-0ubuntu1~16.04.2",
+			"arch": "all"
+		},
+		"cloud-initramfs-copymods": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"cloud-initramfs-dyn-netconf": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"command-not-found": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "all"
+		},
+		"command-not-found-data": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "amd64"
+		},
+		"console-setup": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"console-setup-linux": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"coreutils": {
+			"version": "8.25-2ubuntu3~16.04",
+			"arch": "amd64"
+		},
+		"cpio": {
+			"version": "2.11+dfsg-5ubuntu1",
+			"arch": "amd64"
+		},
+		"cron": {
+			"version": "3.0pl1-128ubuntu2",
+			"arch": "amd64"
+		},
+		"cryptsetup": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"cryptsetup-bin": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"curl": {
+			"version": "7.47.0-1ubuntu2.12",
+			"arch": "amd64"
+		},
+		"dash": {
+			"version": "0.5.8-2.1ubuntu2",
+			"arch": "amd64"
+		},
+		"dbus": {
+			"version": "1.10.6-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"debconf": {
+			"version": "1.5.58ubuntu1",
+			"arch": "all"
+		},
+		"debconf-i18n": {
+			"version": "1.5.58ubuntu1",
+			"arch": "all"
+		},
+		"debianutils": {
+			"version": "4.7",
+			"arch": "amd64"
+		},
+		"dh-python": {
+			"version": "2.20151103ubuntu1.1",
+			"arch": "all"
+		},
+		"diffutils": {
+			"version": "1:3.3-3",
+			"arch": "amd64"
+		},
+		"distro-info-data": {
+			"version": "0.28ubuntu0.9",
+			"arch": "all"
+		},
+		"dmeventd": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"dmidecode": {
+			"version": "3.0-2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"dmsetup": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"dns-root-data": {
+			"version": "2018013001~16.04.1",
+			"arch": "all"
+		},
+		"dnsmasq-base": {
+			"version": "2.75-1ubuntu0.16.04.5",
+			"arch": "amd64"
+		},
+		"dnsutils": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"dosfstools": {
+			"version": "3.0.28-2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"dpkg": {
+			"version": "1.18.4ubuntu1.5",
+			"arch": "amd64"
+		},
+		"e2fslibs": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"e2fsprogs": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"eatmydata": {
+			"version": "105-3",
+			"arch": "all"
+		},
+		"ed": {
+			"version": "1.10-2",
+			"arch": "amd64"
+		},
+		"eject": {
+			"version": "2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"ethtool": {
+			"version": "1:4.5-1",
+			"arch": "amd64"
+		},
+		"file": {
+			"version": "1:5.25-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"findutils": {
+			"version": "4.6.0+git+20160126-2",
+			"arch": "amd64"
+		},
+		"fonts-ubuntu-font-family-console": {
+			"version": "1:0.83-0ubuntu2",
+			"arch": "all"
+		},
+		"friendly-recovery": {
+			"version": "0.2.31ubuntu2",
+			"arch": "all"
+		},
+		"ftp": {
+			"version": "0.17-33",
+			"arch": "amd64"
+		},
+		"fuse": {
+			"version": "2.9.4-1ubuntu3.1",
+			"arch": "amd64"
+		},
+		"gawk": {
+			"version": "1:4.1.3+dfsg-0.1",
+			"arch": "amd64"
+		},
+		"gcc-5-base": {
+			"version": "5.4.0-6ubuntu1~16.04.11",
+			"arch": "amd64"
+		},
+		"gcc-6-base": {
+			"version": "6.0.1-0ubuntu1",
+			"arch": "amd64"
+		},
+		"gdisk": {
+			"version": "1.0.1-1build1",
+			"arch": "amd64"
+		},
+		"geoip-database": {
+			"version": "20160408-1",
+			"arch": "all"
+		},
+		"gettext-base": {
+			"version": "0.19.7-2ubuntu3.1",
+			"arch": "amd64"
+		},
+		"gir1.2-glib-2.0": {
+			"version": "1.46.0-3ubuntu1",
+			"arch": "amd64"
+		},
+		"git": {
+			"version": "1:2.7.4-0ubuntu1.6",
+			"arch": "amd64"
+		},
+		"git-man": {
+			"version": "1:2.7.4-0ubuntu1.6",
+			"arch": "all"
+		},
+		"gnupg": {
+			"version": "1.4.20-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"gpgv": {
+			"version": "1.4.20-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"grep": {
+			"version": "2.25-1~16.04.1",
+			"arch": "amd64"
+		},
+		"groff-base": {
+			"version": "1.22.3-7",
+			"arch": "amd64"
+		},
+		"grub-common": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub-gfxpayload-lists": {
+			"version": "0.7",
+			"arch": "amd64"
+		},
+		"grub-legacy-ec2": {
+			"version": "18.4-0ubuntu1~16.04.2",
+			"arch": "all"
+		},
+		"grub-pc": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub-pc-bin": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub2-common": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"gzip": {
+			"version": "1.6-4ubuntu1",
+			"arch": "amd64"
+		},
+		"hdparm": {
+			"version": "9.48+ds-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"hibagent": {
+			"version": "1.0.1-0ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"hostname": {
+			"version": "3.16ubuntu2",
+			"arch": "amd64"
+		},
+		"ifenslave": {
+			"version": "2.7ubuntu1",
+			"arch": "all"
+		},
+		"ifupdown": {
+			"version": "0.8.10ubuntu1.4",
+			"arch": "amd64"
+		},
+		"info": {
+			"version": "6.1.0.dfsg.1-5",
+			"arch": "amd64"
+		},
+		"init": {
+			"version": "1.29ubuntu4",
+			"arch": "amd64"
+		},
+		"init-system-helpers": {
+			"version": "1.29ubuntu4",
+			"arch": "all"
+		},
+		"initramfs-tools": {
+			"version": "0.122ubuntu8.14",
+			"arch": "all"
+		},
+		"initramfs-tools-bin": {
+			"version": "0.122ubuntu8.14",
+			"arch": "amd64"
+		},
+		"initramfs-tools-core": {
+			"version": "0.122ubuntu8.14",
+			"arch": "all"
+		},
+		"initscripts": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "amd64"
+		},
+		"insserv": {
+			"version": "1.14.0-5ubuntu3",
+			"arch": "amd64"
+		},
+		"install-info": {
+			"version": "6.1.0.dfsg.1-5",
+			"arch": "amd64"
+		},
+		"iproute2": {
+			"version": "4.3.0-1ubuntu3.16.04.4",
+			"arch": "amd64"
+		},
+		"iptables": {
+			"version": "1.6.0-2ubuntu3",
+			"arch": "amd64"
+		},
+		"iputils-ping": {
+			"version": "3:20121221-5ubuntu2",
+			"arch": "amd64"
+		},
+		"iputils-tracepath": {
+			"version": "3:20121221-5ubuntu2",
+			"arch": "amd64"
+		},
+		"irqbalance": {
+			"version": "1.1.0-2ubuntu1",
+			"arch": "amd64"
+		},
+		"isc-dhcp-client": {
+			"version": "4.3.3-5ubuntu12.10",
+			"arch": "amd64"
+		},
+		"isc-dhcp-common": {
+			"version": "4.3.3-5ubuntu12.10",
+			"arch": "amd64"
+		},
+		"iso-codes": {
+			"version": "3.65-1",
+			"arch": "all"
+		},
+		"kbd": {
+			"version": "1.15.5-1ubuntu5",
+			"arch": "amd64"
+		},
+		"keyboard-configuration": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"klibc-utils": {
+			"version": "2.0.4-8ubuntu1.16.04.4",
+			"arch": "amd64"
+		},
+		"kmod": {
+			"version": "22-1ubuntu5.1",
+			"arch": "amd64"
+		},
+		"krb5-locales": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "all"
+		},
+		"language-selector-common": {
+			"version": "0.165.4",
+			"arch": "all"
+		},
+		"less": {
+			"version": "481-2.1ubuntu0.2",
+			"arch": "amd64"
+		},
+		"libaccountsservice0": {
+			"version": "0.6.40-2ubuntu11.3",
+			"arch": "amd64"
+		},
+		"libacl1": {
+			"version": "2.2.52-3",
+			"arch": "amd64"
+		},
+		"libapparmor-perl": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"libapparmor1": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"libapt-inst2.0": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libapt-pkg5.0": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libasn1-8-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libasprintf0v5": {
+			"version": "0.19.7-2ubuntu3.1",
+			"arch": "amd64"
+		},
+		"libatm1": {
+			"version": "1:2.5.1-1.5",
+			"arch": "amd64"
+		},
+		"libattr1": {
+			"version": "1:2.4.47-2",
+			"arch": "amd64"
+		},
+		"libaudit-common": {
+			"version": "1:2.4.5-1ubuntu2.1",
+			"arch": "all"
+		},
+		"libaudit1": {
+			"version": "1:2.4.5-1ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libbind9-140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libblkid1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libbsd0": {
+			"version": "0.8.2-1",
+			"arch": "amd64"
+		},
+		"libbz2-1.0": {
+			"version": "1.0.6-8",
+			"arch": "amd64"
+		},
+		"libc-bin": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"libc6": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"libcap-ng0": {
+			"version": "0.7.7-1",
+			"arch": "amd64"
+		},
+		"libcap2": {
+			"version": "1:2.24-12",
+			"arch": "amd64"
+		},
+		"libcap2-bin": {
+			"version": "1:2.24-12",
+			"arch": "amd64"
+		},
+		"libcomerr2": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libcryptsetup4": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libcurl3-gnutls": {
+			"version": "7.47.0-1ubuntu2.12",
+			"arch": "amd64"
+		},
+		"libdb5.3": {
+			"version": "5.3.28-11ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libdbus-1-3": {
+			"version": "1.10.6-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"libdbus-glib-1-2": {
+			"version": "0.106-1",
+			"arch": "amd64"
+		},
+		"libdebconfclient0": {
+			"version": "0.198ubuntu1",
+			"arch": "amd64"
+		},
+		"libdevmapper-event1.02.1": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"libdevmapper1.02.1": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"libdns-export162": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libdns162": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libdrm-common": {
+			"version": "2.4.91-2~16.04.1",
+			"arch": "all"
+		},
+		"libdrm2": {
+			"version": "2.4.91-2~16.04.1",
+			"arch": "amd64"
+		},
+		"libdumbnet1": {
+			"version": "1.12-7",
+			"arch": "amd64"
+		},
+		"libeatmydata1": {
+			"version": "105-3",
+			"arch": "amd64"
+		},
+		"libedit2": {
+			"version": "3.1-20150325-1ubuntu2",
+			"arch": "amd64"
+		},
+		"libelf1": {
+			"version": "0.165-3ubuntu1.1",
+			"arch": "amd64"
+		},
+		"liberror-perl": {
+			"version": "0.17-1.2",
+			"arch": "all"
+		},
+		"libestr0": {
+			"version": "0.1.10-1",
+			"arch": "amd64"
+		},
+		"libevent-2.0-5": {
+			"version": "2.0.21-stable-2ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libexpat1": {
+			"version": "2.1.0-7ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libfdisk1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libffi6": {
+			"version": "3.2.1-4",
+			"arch": "amd64"
+		},
+		"libfreetype6": {
+			"version": "2.6.1-0.1ubuntu2.3",
+			"arch": "amd64"
+		},
+		"libfribidi0": {
+			"version": "0.19.7-1",
+			"arch": "amd64"
+		},
+		"libfuse2": {
+			"version": "2.9.4-1ubuntu3.1",
+			"arch": "amd64"
+		},
+		"libgcc1": {
+			"version": "1:6.0.1-0ubuntu1",
+			"arch": "amd64"
+		},
+		"libgcrypt20": {
+			"version": "1.6.5-2ubuntu0.5",
+			"arch": "amd64"
+		},
+		"libgdbm3": {
+			"version": "1.8.3-13.1",
+			"arch": "amd64"
+		},
+		"libgeoip1": {
+			"version": "1.6.9-1",
+			"arch": "amd64"
+		},
+		"libgirepository-1.0-1": {
+			"version": "1.46.0-3ubuntu1",
+			"arch": "amd64"
+		},
+		"libglib2.0-0": {
+			"version": "2.48.2-0ubuntu4.1",
+			"arch": "amd64"
+		},
+		"libglib2.0-data": {
+			"version": "2.48.2-0ubuntu4.1",
+			"arch": "all"
+		},
+		"libgmp10": {
+			"version": "2:6.1.0+dfsg-2",
+			"arch": "amd64"
+		},
+		"libgnutls-openssl27": {
+			"version": "3.4.10-4ubuntu1.4",
+			"arch": "amd64"
+		},
+		"libgnutls30": {
+			"version": "3.4.10-4ubuntu1.4",
+			"arch": "amd64"
+		},
+		"libgpg-error0": {
+			"version": "1.21-2ubuntu1",
+			"arch": "amd64"
+		},
+		"libgpm2": {
+			"version": "1.20.4-6.1",
+			"arch": "amd64"
+		},
+		"libgssapi-krb5-2": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libgssapi3-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libhcrypto4-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libheimbase1-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libheimntlm0-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libhogweed4": {
+			"version": "3.2-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libhx509-5-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libicu55": {
+			"version": "55.1-7ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libidn11": {
+			"version": "1.32-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"libisc-export160": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisc160": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisccc140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisccfg140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libjson-c2": {
+			"version": "0.11-4ubuntu2",
+			"arch": "amd64"
+		},
+		"libk5crypto3": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libkeyutils1": {
+			"version": "1.5.9-8ubuntu1",
+			"arch": "amd64"
+		},
+		"libklibc": {
+			"version": "2.0.4-8ubuntu1.16.04.4",
+			"arch": "amd64"
+		},
+		"libkmod2": {
+			"version": "22-1ubuntu5.1",
+			"arch": "amd64"
+		},
+		"libkrb5-26-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libkrb5-3": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libkrb5support0": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libldap-2.4-2": {
+			"version": "2.4.42+dfsg-2ubuntu3.4",
+			"arch": "amd64"
+		},
+		"liblocale-gettext-perl": {
+			"version": "1.07-1build1",
+			"arch": "amd64"
+		},
+		"liblvm2app2.2": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"liblvm2cmd2.02": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"liblwres141": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"liblxc1": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"liblz4-1": {
+			"version": "0.0~r131-2ubuntu2",
+			"arch": "amd64"
+		},
+		"liblzma5": {
+			"version": "5.1.1alpha+20120614-2ubuntu2",
+			"arch": "amd64"
+		},
+		"liblzo2-2": {
+			"version": "2.08-1.2",
+			"arch": "amd64"
+		},
+		"libmagic1": {
+			"version": "1:5.25-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libmnl0": {
+			"version": "1.0.3-5",
+			"arch": "amd64"
+		},
+		"libmount1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libmpdec2": {
+			"version": "2.4.2-1",
+			"arch": "amd64"
+		},
+		"libmpfr4": {
+			"version": "3.1.4-1",
+			"arch": "amd64"
+		},
+		"libmspack0": {
+			"version": "0.5-1ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libncurses5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libncursesw5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libnetfilter-conntrack3": {
+			"version": "1.0.5-1",
+			"arch": "amd64"
+		},
+		"libnettle6": {
+			"version": "3.2-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libnewt0.52": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"libnfnetlink0": {
+			"version": "1.0.1-3",
+			"arch": "amd64"
+		},
+		"libnih1": {
+			"version": "1.0.3-4.3ubuntu1",
+			"arch": "amd64"
+		},
+		"libnuma1": {
+			"version": "2.0.11-1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libp11-kit0": {
+			"version": "0.23.2-5~ubuntu16.04.1",
+			"arch": "amd64"
+		},
+		"libpam-modules": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libpam-modules-bin": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libpam-runtime": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "all"
+		},
+		"libpam-systemd": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libpam0g": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libparted2": {
+			"version": "3.2-15ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libpcap0.8": {
+			"version": "1.7.4-2",
+			"arch": "amd64"
+		},
+		"libpci3": {
+			"version": "1:3.3.1-1.1ubuntu1.2",
+			"arch": "amd64"
+		},
+		"libpcre3": {
+			"version": "2:8.38-3.1",
+			"arch": "amd64"
+		},
+		"libperl5.22": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"libpipeline1": {
+			"version": "1.4.1-2",
+			"arch": "amd64"
+		},
+		"libplymouth4": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"libpng12-0": {
+			"version": "1.2.54-1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libpolkit-agent-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpolkit-backend-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpolkit-gobject-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpopt0": {
+			"version": "1.16-10",
+			"arch": "amd64"
+		},
+		"libprocps4": {
+			"version": "2:3.3.10-4ubuntu2.4",
+			"arch": "amd64"
+		},
+		"libpython3-stdlib": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"libpython3.5": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libpython3.5-minimal": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libpython3.5-stdlib": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libreadline5": {
+			"version": "5.2+dfsg-3build1",
+			"arch": "amd64"
+		},
+		"libreadline6": {
+			"version": "6.3-8ubuntu2",
+			"arch": "amd64"
+		},
+		"libroken18-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"librtmp1": {
+			"version": "2.4+20151223.gitfa8646d-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-2": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-modules": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-modules-db": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libseccomp2": {
+			"version": "2.3.1-2.1ubuntu2~16.04.1",
+			"arch": "amd64"
+		},
+		"libselinux1": {
+			"version": "2.4-3build2",
+			"arch": "amd64"
+		},
+		"libsemanage-common": {
+			"version": "2.3-1build3",
+			"arch": "all"
+		},
+		"libsemanage1": {
+			"version": "2.3-1build3",
+			"arch": "amd64"
+		},
+		"libsepol1": {
+			"version": "2.4-2",
+			"arch": "amd64"
+		},
+		"libsigsegv2": {
+			"version": "2.10-4",
+			"arch": "amd64"
+		},
+		"libslang2": {
+			"version": "2.3.0-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libsmartcols1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libsqlite3-0": {
+			"version": "3.11.0-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libss2": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libssl1.0.0": {
+			"version": "1.0.2g-1ubuntu4.14",
+			"arch": "amd64"
+		},
+		"libstdc++6": {
+			"version": "5.4.0-6ubuntu1~16.04.11",
+			"arch": "amd64"
+		},
+		"libsystemd0": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libtasn1-6": {
+			"version": "4.7-3ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libtext-charwidth-perl": {
+			"version": "0.04-7build5",
+			"arch": "amd64"
+		},
+		"libtext-iconv-perl": {
+			"version": "1.7-5build4",
+			"arch": "amd64"
+		},
+		"libtext-wrapi18n-perl": {
+			"version": "0.06-7.1",
+			"arch": "all"
+		},
+		"libtinfo5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libudev1": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libusb-0.1-4": {
+			"version": "2:0.1.12-28",
+			"arch": "amd64"
+		},
+		"libusb-1.0-0": {
+			"version": "2:1.0.20-1",
+			"arch": "amd64"
+		},
+		"libustr-1.0-1": {
+			"version": "1.0.4-5",
+			"arch": "amd64"
+		},
+		"libutempter0": {
+			"version": "1.1.6-3",
+			"arch": "amd64"
+		},
+		"libuuid1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libwind0-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libwrap0": {
+			"version": "7.6.q-25",
+			"arch": "amd64"
+		},
+		"libx11-6": {
+			"version": "2:1.6.3-1ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libx11-data": {
+			"version": "2:1.6.3-1ubuntu2.1",
+			"arch": "all"
+		},
+		"libxau6": {
+			"version": "1:1.0.8-1",
+			"arch": "amd64"
+		},
+		"libxcb1": {
+			"version": "1.11.1-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libxdmcp6": {
+			"version": "1:1.1.2-1.1",
+			"arch": "amd64"
+		},
+		"libxext6": {
+			"version": "2:1.3.3-1",
+			"arch": "amd64"
+		},
+		"libxml2": {
+			"version": "2.9.3+dfsg1-1ubuntu0.6",
+			"arch": "amd64"
+		},
+		"libxmlsec1": {
+			"version": "1.2.20-2ubuntu4",
+			"arch": "amd64"
+		},
+		"libxmlsec1-openssl": {
+			"version": "1.2.20-2ubuntu4",
+			"arch": "amd64"
+		},
+		"libxmuu1": {
+			"version": "2:1.1.2-2",
+			"arch": "amd64"
+		},
+		"libxslt1.1": {
+			"version": "1.1.28-2.1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libxtables11": {
+			"version": "1.6.0-2ubuntu3",
+			"arch": "amd64"
+		},
+		"libyaml-0-2": {
+			"version": "0.1.6-3",
+			"arch": "amd64"
+		},
+		"linux-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"linux-aws-headers-4.4.0-1075": {
+			"version": "4.4.0-1075.85",
+			"arch": "all"
+		},
+		"linux-base": {
+			"version": "4.5ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"linux-headers-4.4.0-1075-aws": {
+			"version": "4.4.0-1075.85",
+			"arch": "amd64"
+		},
+		"linux-headers-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"linux-image-4.4.0-1075-aws": {
+			"version": "4.4.0-1075.85",
+			"arch": "amd64"
+		},
+		"linux-image-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"locales": {
+			"version": "2.23-0ubuntu10",
+			"arch": "all"
+		},
+		"login": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"logrotate": {
+			"version": "3.8.7-2ubuntu2.16.04.2",
+			"arch": "amd64"
+		},
+		"lsb-base": {
+			"version": "9.20160110ubuntu0.2",
+			"arch": "all"
+		},
+		"lsb-release": {
+			"version": "9.20160110ubuntu0.2",
+			"arch": "all"
+		},
+		"lshw": {
+			"version": "02.17-1.1ubuntu3.5",
+			"arch": "amd64"
+		},
+		"lsof": {
+			"version": "4.89+dfsg-0.1",
+			"arch": "amd64"
+		},
+		"ltrace": {
+			"version": "0.7.3-5.1ubuntu4",
+			"arch": "amd64"
+		},
+		"lvm2": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"lxc-common": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"lxcfs": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"lxd": {
+			"version": "2.0.11-0ubuntu1~16.04.4",
+			"arch": "amd64"
+		},
+		"lxd-client": {
+			"version": "2.0.11-0ubuntu1~16.04.4",
+			"arch": "amd64"
+		},
+		"makedev": {
+			"version": "2.3.1-93ubuntu2~ubuntu16.04.1",
+			"arch": "all"
+		},
+		"man-db": {
+			"version": "2.7.5-1",
+			"arch": "amd64"
+		},
+		"manpages": {
+			"version": "4.04-2",
+			"arch": "all"
+		},
+		"mawk": {
+			"version": "1.3.3-17ubuntu2",
+			"arch": "amd64"
+		},
+		"mdadm": {
+			"version": "3.3-2ubuntu7.6",
+			"arch": "amd64"
+		},
+		"mime-support": {
+			"version": "3.59ubuntu1",
+			"arch": "all"
+		},
+		"mlocate": {
+			"version": "0.26-1ubuntu2",
+			"arch": "amd64"
+		},
+		"mount": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"mtr-tiny": {
+			"version": "0.86-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"multiarch-support": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"nano": {
+			"version": "2.5.3-2ubuntu2",
+			"arch": "amd64"
+		},
+		"ncurses-base": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "all"
+		},
+		"ncurses-bin": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"ncurses-term": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "all"
+		},
+		"net-tools": {
+			"version": "1.60-26ubuntu1",
+			"arch": "amd64"
+		},
+		"netbase": {
+			"version": "5.3",
+			"arch": "all"
+		},
+		"netcat-openbsd": {
+			"version": "1.105-7ubuntu1",
+			"arch": "amd64"
+		},
+		"ntfs-3g": {
+			"version": "1:2015.3.14AR.1-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"open-iscsi": {
+			"version": "2.0.873+git0.3b4b4500-14ubuntu3.7",
+			"arch": "amd64"
+		},
+		"open-vm-tools": {
+			"version": "2:10.2.0-3~ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"openssh-client": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssh-server": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssh-sftp-server": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssl": {
+			"version": "1.0.2g-1ubuntu4.14",
+			"arch": "amd64"
+		},
+		"os-prober": {
+			"version": "1.70ubuntu3.3",
+			"arch": "amd64"
+		},
+		"overlayroot": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"parted": {
+			"version": "3.2-15ubuntu0.1",
+			"arch": "amd64"
+		},
+		"passwd": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"pastebinit": {
+			"version": "1.5-1",
+			"arch": "all"
+		},
+		"patch": {
+			"version": "2.7.5-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"pciutils": {
+			"version": "1:3.3.1-1.1ubuntu1.2",
+			"arch": "amd64"
+		},
+		"perl": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"perl-base": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"perl-modules-5.22": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "all"
+		},
+		"plymouth": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"plymouth-theme-ubuntu-text": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"policykit-1": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"pollinate": {
+			"version": "4.33-0ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"popularity-contest": {
+			"version": "1.64ubuntu2",
+			"arch": "all"
+		},
+		"powermgmt-base": {
+			"version": "1.31+nmu1",
+			"arch": "all"
+		},
+		"procps": {
+			"version": "2:3.3.10-4ubuntu2.4",
+			"arch": "amd64"
+		},
+		"psmisc": {
+			"version": "22.21-2.1build1",
+			"arch": "amd64"
+		},
+		"python-apt-common": {
+			"version": "1.1.0~beta1ubuntu0.16.04.2",
+			"arch": "all"
+		},
+		"python3": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"python3-apport": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"python3-apt": {
+			"version": "1.1.0~beta1ubuntu0.16.04.2",
+			"arch": "amd64"
+		},
+		"python3-blinker": {
+			"version": "1.3.dfsg2-1build1",
+			"arch": "all"
+		},
+		"python3-cffi-backend": {
+			"version": "1.5.2-1ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-chardet": {
+			"version": "2.3.0-2",
+			"arch": "all"
+		},
+		"python3-commandnotfound": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "all"
+		},
+		"python3-configobj": {
+			"version": "5.0.6-2",
+			"arch": "all"
+		},
+		"python3-cryptography": {
+			"version": "1.2.3-1ubuntu0.2",
+			"arch": "amd64"
+		},
+		"python3-dbus": {
+			"version": "1.2.0-3",
+			"arch": "amd64"
+		},
+		"python3-debian": {
+			"version": "0.1.27ubuntu2",
+			"arch": "all"
+		},
+		"python3-distupgrade": {
+			"version": "1:16.04.26",
+			"arch": "all"
+		},
+		"python3-gdbm": {
+			"version": "3.5.1-1",
+			"arch": "amd64"
+		},
+		"python3-gi": {
+			"version": "3.20.0-0ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-idna": {
+			"version": "2.0-3",
+			"arch": "all"
+		},
+		"python3-jinja2": {
+			"version": "2.8-1",
+			"arch": "all"
+		},
+		"python3-json-pointer": {
+			"version": "1.9-3",
+			"arch": "all"
+		},
+		"python3-jsonpatch": {
+			"version": "1.19-3",
+			"arch": "all"
+		},
+		"python3-jwt": {
+			"version": "1.3.0-1ubuntu0.1",
+			"arch": "all"
+		},
+		"python3-markupsafe": {
+			"version": "0.23-2build2",
+			"arch": "amd64"
+		},
+		"python3-minimal": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"python3-newt": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"python3-oauthlib": {
+			"version": "1.0.3-1",
+			"arch": "all"
+		},
+		"python3-pkg-resources": {
+			"version": "20.7.0-1",
+			"arch": "all"
+		},
+		"python3-prettytable": {
+			"version": "0.7.2-3",
+			"arch": "all"
+		},
+		"python3-problem-report": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"python3-pyasn1": {
+			"version": "0.1.9-1",
+			"arch": "all"
+		},
+		"python3-pycurl": {
+			"version": "7.43.0-1ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-requests": {
+			"version": "2.9.1-3ubuntu0.1",
+			"arch": "all"
+		},
+		"python3-serial": {
+			"version": "3.0.1-1",
+			"arch": "all"
+		},
+		"python3-six": {
+			"version": "1.10.0-3",
+			"arch": "all"
+		},
+		"python3-software-properties": {
+			"version": "0.96.20.8",
+			"arch": "all"
+		},
+		"python3-systemd": {
+			"version": "231-2build1",
+			"arch": "amd64"
+		},
+		"python3-update-manager": {
+			"version": "1:16.04.15",
+			"arch": "all"
+		},
+		"python3-urllib3": {
+			"version": "1.13.1-2ubuntu0.16.04.2",
+			"arch": "all"
+		},
+		"python3-yaml": {
+			"version": "3.11-3build1",
+			"arch": "amd64"
+		},
+		"python3.5": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"python3.5-minimal": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"readline-common": {
+			"version": "6.3-8ubuntu2",
+			"arch": "all"
+		},
+		"rename": {
+			"version": "0.20-4",
+			"arch": "all"
+		},
+		"resolvconf": {
+			"version": "1.78ubuntu6",
+			"arch": "all"
+		},
+		"rsync": {
+			"version": "3.1.1-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"rsyslog": {
+			"version": "8.16.0-1ubuntu3",
+			"arch": "amd64"
+		},
+		"run-one": {
+			"version": "1.17-0ubuntu1",
+			"arch": "all"
+		},
+		"screen": {
+			"version": "4.3.1-2build1",
+			"arch": "amd64"
+		},
+		"sed": {
+			"version": "4.2.2-7",
+			"arch": "amd64"
+		},
+		"sensible-utils": {
+			"version": "0.0.9ubuntu0.16.04.1",
+			"arch": "all"
+		},
+		"sgml-base": {
+			"version": "1.26+nmu4ubuntu1",
+			"arch": "all"
+		},
+		"shared-mime-info": {
+			"version": "1.5-2ubuntu0.2",
+			"arch": "amd64"
+		},
+		"snapd": {
+			"version": "2.34.2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"software-properties-common": {
+			"version": "0.96.20.8",
+			"arch": "all"
+		},
+		"sosreport": {
+			"version": "3.6-1ubuntu0.16.04.2",
+			"arch": "amd64"
+		},
+		"squashfs-tools": {
+			"version": "1:4.3-3ubuntu2.16.04.3",
+			"arch": "amd64"
+		},
+		"ssh-import-id": {
+			"version": "5.5-0ubuntu1",
+			"arch": "all"
+		},
+		"strace": {
+			"version": "4.11-1ubuntu3",
+			"arch": "amd64"
+		},
+		"sudo": {
+			"version": "1.8.16-0ubuntu1.5",
+			"arch": "amd64"
+		},
+		"systemd": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"systemd-sysv": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"sysv-rc": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "all"
+		},
+		"sysvinit-utils": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "amd64"
+		},
+		"tar": {
+			"version": "1.28-2.1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"tcpd": {
+			"version": "7.6.q-25",
+			"arch": "amd64"
+		},
+		"tcpdump": {
+			"version": "4.9.2-0ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"telnet": {
+			"version": "0.17-40",
+			"arch": "amd64"
+		},
+		"time": {
+			"version": "1.7-25.1",
+			"arch": "amd64"
+		},
+		"tmux": {
+			"version": "2.1-3build1",
+			"arch": "amd64"
+		},
+		"tzdata": {
+			"version": "2018i-0ubuntu0.16.04",
+			"arch": "all"
+		},
+		"ubuntu-advantage-tools": {
+			"version": "10ubuntu0.16.04.1",
+			"arch": "all"
+		},
+		"ubuntu-cloudimage-keyring": {
+			"version": "2013.11.11",
+			"arch": "all"
+		},
+		"ubuntu-core-launcher": {
+			"version": "2.34.2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"ubuntu-keyring": {
+			"version": "2012.05.19",
+			"arch": "all"
+		},
+		"ubuntu-minimal": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ubuntu-release-upgrader-core": {
+			"version": "1:16.04.26",
+			"arch": "all"
+		},
+		"ubuntu-server": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ubuntu-standard": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ucf": {
+			"version": "3.0036",
+			"arch": "all"
+		},
+		"udev": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"ufw": {
+			"version": "0.35-0ubuntu2",
+			"arch": "all"
+		},
+		"uidmap": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"unattended-upgrades": {
+			"version": "0.90ubuntu0.10",
+			"arch": "all"
+		},
+		"update-manager-core": {
+			"version": "1:16.04.15",
+			"arch": "all"
+		},
+		"update-notifier-common": {
+			"version": "3.168.10",
+			"arch": "all"
+		},
+		"ureadahead": {
+			"version": "0.100.0-19",
+			"arch": "amd64"
+		},
+		"usbutils": {
+			"version": "1:007-4",
+			"arch": "amd64"
+		},
+		"util-linux": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"uuid-runtime": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"vim": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vim-common": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vim-runtime": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "all"
+		},
+		"vim-tiny": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vlan": {
+			"version": "1.9-3.2ubuntu1.16.04.5",
+			"arch": "amd64"
+		},
+		"wget": {
+			"version": "1.17.1-1ubuntu1.4",
+			"arch": "amd64"
+		},
+		"whiptail": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"xauth": {
+			"version": "1:1.0.9-1ubuntu2",
+			"arch": "amd64"
+		},
+		"xdg-user-dirs": {
+			"version": "0.15-2ubuntu6.16.04.1",
+			"arch": "amd64"
+		},
+		"xfsprogs": {
+			"version": "4.3.0+nmu1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"xkb-data": {
+			"version": "2.16-1ubuntu1",
+			"arch": "all"
+		},
+		"xml-core": {
+			"version": "0.13+nmu2",
+			"arch": "all"
+		},
+		"xz-utils": {
+			"version": "5.1.1alpha+20120614-2ubuntu2",
+			"arch": "amd64"
+		},
+		"zerofree": {
+			"version": "1.0.3-1",
+			"arch": "amd64"
+		},
+		"zlib1g": {
+			"version": "1:1.2.8.dfsg-2ubuntu4.1",
+			"arch": "amd64"
+		}
+	},
+	"platform": "ubuntu",
+	"platform_family": "debian",
+	"platform_version": "16.04",
+	"root_group": "root",
+	"shard_seed": 163378034,
+	"shells": [
+		"/bin/sh",
+		"/bin/dash",
+		"/bin/bash",
+		"/bin/rbash",
+		"/usr/bin/tmux",
+		"/usr/bin/screen"
+	],
+	"sysconf": {
+		"LINK_MAX": 65000,
+		"_POSIX_LINK_MAX": 65000,
+		"MAX_CANON": 255,
+		"_POSIX_MAX_CANON": 255,
+		"MAX_INPUT": 255,
+		"_POSIX_MAX_INPUT": 255,
+		"NAME_MAX": 255,
+		"_POSIX_NAME_MAX": 255,
+		"PATH_MAX": 4096,
+		"_POSIX_PATH_MAX": 4096,
+		"PIPE_BUF": 4096,
+		"_POSIX_PIPE_BUF": 4096,
+		"SOCK_MAXBUF": null,
+		"_POSIX_ASYNC_IO": null,
+		"_POSIX_CHOWN_RESTRICTED": 1,
+		"_POSIX_NO_TRUNC": 1,
+		"_POSIX_PRIO_IO": null,
+		"_POSIX_SYNC_IO": null,
+		"_POSIX_VDISABLE": 0,
+		"ARG_MAX": 2097152,
+		"ATEXIT_MAX": 2147483647,
+		"CHAR_BIT": 8,
+		"CHAR_MAX": 127,
+		"CHAR_MIN": -128,
+		"CHILD_MAX": 3900,
+		"CLK_TCK": 100,
+		"INT_MAX": 2147483647,
+		"INT_MIN": -2147483648,
+		"IOV_MAX": 1024,
+		"LOGNAME_MAX": 256,
+		"LONG_BIT": 64,
+		"MB_LEN_MAX": 16,
+		"NGROUPS_MAX": 65536,
+		"NL_ARGMAX": 4096,
+		"NL_LANGMAX": 2048,
+		"NL_MSGMAX": 2147483647,
+		"NL_NMAX": 2147483647,
+		"NL_SETMAX": 2147483647,
+		"NL_TEXTMAX": 2147483647,
+		"NSS_BUFLEN_GROUP": 1024,
+		"NSS_BUFLEN_PASSWD": 1024,
+		"NZERO": 20,
+		"OPEN_MAX": 1024,
+		"PAGESIZE": 4096,
+		"PAGE_SIZE": 4096,
+		"PASS_MAX": 8192,
+		"PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+		"PTHREAD_KEYS_MAX": 1024,
+		"PTHREAD_STACK_MIN": 16384,
+		"PTHREAD_THREADS_MAX": null,
+		"SCHAR_MAX": 127,
+		"SCHAR_MIN": -128,
+		"SHRT_MAX": 32767,
+		"SHRT_MIN": -32768,
+		"SSIZE_MAX": 32767,
+		"TTY_NAME_MAX": 32,
+		"TZNAME_MAX": 6,
+		"UCHAR_MAX": 255,
+		"UINT_MAX": 4294967295,
+		"UIO_MAXIOV": 1024,
+		"ULONG_MAX": 18446744073709552000,
+		"USHRT_MAX": 65535,
+		"WORD_BIT": 32,
+		"_AVPHYS_PAGES": 74149,
+		"_NPROCESSORS_CONF": 1,
+		"_NPROCESSORS_ONLN": 1,
+		"_PHYS_PAGES": 253609,
+		"_POSIX_ARG_MAX": 2097152,
+		"_POSIX_ASYNCHRONOUS_IO": 200809,
+		"_POSIX_CHILD_MAX": 3900,
+		"_POSIX_FSYNC": 200809,
+		"_POSIX_JOB_CONTROL": 1,
+		"_POSIX_MAPPED_FILES": 200809,
+		"_POSIX_MEMLOCK": 200809,
+		"_POSIX_MEMLOCK_RANGE": 200809,
+		"_POSIX_MEMORY_PROTECTION": 200809,
+		"_POSIX_MESSAGE_PASSING": 200809,
+		"_POSIX_NGROUPS_MAX": 65536,
+		"_POSIX_OPEN_MAX": 1024,
+		"_POSIX_PII": null,
+		"_POSIX_PII_INTERNET": null,
+		"_POSIX_PII_INTERNET_DGRAM": null,
+		"_POSIX_PII_INTERNET_STREAM": null,
+		"_POSIX_PII_OSI": null,
+		"_POSIX_PII_OSI_CLTS": null,
+		"_POSIX_PII_OSI_COTS": null,
+		"_POSIX_PII_OSI_M": null,
+		"_POSIX_PII_SOCKET": null,
+		"_POSIX_PII_XTI": null,
+		"_POSIX_POLL": null,
+		"_POSIX_PRIORITIZED_IO": 200809,
+		"_POSIX_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_REALTIME_SIGNALS": 200809,
+		"_POSIX_SAVED_IDS": 1,
+		"_POSIX_SELECT": null,
+		"_POSIX_SEMAPHORES": 200809,
+		"_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+		"_POSIX_SSIZE_MAX": 32767,
+		"_POSIX_STREAM_MAX": 16,
+		"_POSIX_SYNCHRONIZED_IO": 200809,
+		"_POSIX_THREADS": 200809,
+		"_POSIX_THREAD_ATTR_STACKADDR": 200809,
+		"_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+		"_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_THREAD_PRIO_INHERIT": 200809,
+		"_POSIX_THREAD_PRIO_PROTECT": 200809,
+		"_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+		"_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+		"_POSIX_THREAD_PROCESS_SHARED": 200809,
+		"_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+		"_POSIX_TIMERS": 200809,
+		"TIMER_MAX": null,
+		"_POSIX_TZNAME_MAX": 6,
+		"_POSIX_VERSION": 200809,
+		"_T_IOV_MAX": null,
+		"_XOPEN_CRYPT": 1,
+		"_XOPEN_ENH_I18N": 1,
+		"_XOPEN_LEGACY": 1,
+		"_XOPEN_REALTIME": 1,
+		"_XOPEN_REALTIME_THREADS": 1,
+		"_XOPEN_SHM": 1,
+		"_XOPEN_UNIX": 1,
+		"_XOPEN_VERSION": 700,
+		"_XOPEN_XCU_VERSION": 4,
+		"_XOPEN_XPG2": 1,
+		"_XOPEN_XPG3": 1,
+		"_XOPEN_XPG4": 1,
+		"BC_BASE_MAX": 99,
+		"BC_DIM_MAX": 2048,
+		"BC_SCALE_MAX": 99,
+		"BC_STRING_MAX": 1000,
+		"CHARCLASS_NAME_MAX": 2048,
+		"COLL_WEIGHTS_MAX": 255,
+		"EQUIV_CLASS_MAX": null,
+		"EXPR_NEST_MAX": 32,
+		"LINE_MAX": 2048,
+		"POSIX2_BC_BASE_MAX": 99,
+		"POSIX2_BC_DIM_MAX": 2048,
+		"POSIX2_BC_SCALE_MAX": 99,
+		"POSIX2_BC_STRING_MAX": 1000,
+		"POSIX2_CHAR_TERM": 200809,
+		"POSIX2_COLL_WEIGHTS_MAX": 255,
+		"POSIX2_C_BIND": 200809,
+		"POSIX2_C_DEV": 200809,
+		"POSIX2_C_VERSION": 200809,
+		"POSIX2_EXPR_NEST_MAX": 32,
+		"POSIX2_FORT_DEV": null,
+		"POSIX2_FORT_RUN": null,
+		"_POSIX2_LINE_MAX": 2048,
+		"POSIX2_LINE_MAX": 2048,
+		"POSIX2_LOCALEDEF": 200809,
+		"POSIX2_RE_DUP_MAX": 32767,
+		"POSIX2_SW_DEV": 200809,
+		"POSIX2_UPE": null,
+		"POSIX2_VERSION": 200809,
+		"RE_DUP_MAX": 32767,
+		"PATH": "/bin:/usr/bin",
+		"CS_PATH": "/bin:/usr/bin",
+		"LFS_CFLAGS": null,
+		"LFS_LDFLAGS": null,
+		"LFS_LIBS": null,
+		"LFS_LINTFLAGS": null,
+		"LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+		"LFS64_LDFLAGS": null,
+		"LFS64_LIBS": null,
+		"LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+		"_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"_XBS5_ILP32_OFF32": null,
+		"XBS5_ILP32_OFF32_CFLAGS": null,
+		"XBS5_ILP32_OFF32_LDFLAGS": null,
+		"XBS5_ILP32_OFF32_LIBS": null,
+		"XBS5_ILP32_OFF32_LINTFLAGS": null,
+		"_XBS5_ILP32_OFFBIG": null,
+		"XBS5_ILP32_OFFBIG_CFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LDFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LIBS": null,
+		"XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+		"_XBS5_LP64_OFF64": 1,
+		"XBS5_LP64_OFF64_CFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LDFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LIBS": null,
+		"XBS5_LP64_OFF64_LINTFLAGS": null,
+		"_XBS5_LPBIG_OFFBIG": null,
+		"XBS5_LPBIG_OFFBIG_CFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LIBS": null,
+		"XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_ILP32_OFF32": null,
+		"POSIX_V6_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LIBS": null,
+		"POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"_POSIX_V6_ILP32_OFFBIG": null,
+		"POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_LP64_OFF64": 1,
+		"POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LIBS": null,
+		"POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V6_LPBIG_OFFBIG": null,
+		"POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_ILP32_OFF32": null,
+		"POSIX_V7_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LIBS": null,
+		"POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"_POSIX_V7_ILP32_OFFBIG": null,
+		"POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_LP64_OFF64": 1,
+		"POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LIBS": null,
+		"POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V7_LPBIG_OFFBIG": null,
+		"POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_ADVISORY_INFO": 200809,
+		"_POSIX_BARRIERS": 200809,
+		"_POSIX_BASE": null,
+		"_POSIX_C_LANG_SUPPORT": null,
+		"_POSIX_C_LANG_SUPPORT_R": null,
+		"_POSIX_CLOCK_SELECTION": 200809,
+		"_POSIX_CPUTIME": 200809,
+		"_POSIX_THREAD_CPUTIME": 200809,
+		"_POSIX_DEVICE_SPECIFIC": null,
+		"_POSIX_DEVICE_SPECIFIC_R": null,
+		"_POSIX_FD_MGMT": null,
+		"_POSIX_FIFO": null,
+		"_POSIX_PIPE": null,
+		"_POSIX_FILE_ATTRIBUTES": null,
+		"_POSIX_FILE_LOCKING": null,
+		"_POSIX_FILE_SYSTEM": null,
+		"_POSIX_MONOTONIC_CLOCK": 200809,
+		"_POSIX_MULTI_PROCESS": null,
+		"_POSIX_SINGLE_PROCESS": null,
+		"_POSIX_NETWORKING": null,
+		"_POSIX_READER_WRITER_LOCKS": 200809,
+		"_POSIX_SPIN_LOCKS": 200809,
+		"_POSIX_REGEXP": 1,
+		"_REGEX_VERSION": null,
+		"_POSIX_SHELL": 1,
+		"_POSIX_SIGNALS": null,
+		"_POSIX_SPAWN": 200809,
+		"_POSIX_SPORADIC_SERVER": null,
+		"_POSIX_THREAD_SPORADIC_SERVER": null,
+		"_POSIX_SYSTEM_DATABASE": null,
+		"_POSIX_SYSTEM_DATABASE_R": null,
+		"_POSIX_TIMEOUTS": 200809,
+		"_POSIX_TYPED_MEMORY_OBJECTS": null,
+		"_POSIX_USER_GROUPS": null,
+		"_POSIX_USER_GROUPS_R": null,
+		"POSIX2_PBS": null,
+		"POSIX2_PBS_ACCOUNTING": null,
+		"POSIX2_PBS_LOCATE": null,
+		"POSIX2_PBS_TRACK": null,
+		"POSIX2_PBS_MESSAGE": null,
+		"SYMLOOP_MAX": null,
+		"STREAM_MAX": 16,
+		"AIO_LISTIO_MAX": null,
+		"AIO_MAX": null,
+		"AIO_PRIO_DELTA_MAX": 20,
+		"DELAYTIMER_MAX": 2147483647,
+		"HOST_NAME_MAX": 64,
+		"LOGIN_NAME_MAX": 256,
+		"MQ_OPEN_MAX": null,
+		"MQ_PRIO_MAX": 32768,
+		"_POSIX_DEVICE_IO": null,
+		"_POSIX_TRACE": null,
+		"_POSIX_TRACE_EVENT_FILTER": null,
+		"_POSIX_TRACE_INHERIT": null,
+		"_POSIX_TRACE_LOG": null,
+		"RTSIG_MAX": 32,
+		"SEM_NSEMS_MAX": null,
+		"SEM_VALUE_MAX": 2147483647,
+		"SIGQUEUE_MAX": 3900,
+		"FILESIZEBITS": 64,
+		"POSIX_ALLOC_SIZE_MIN": 4096,
+		"POSIX_REC_INCR_XFER_SIZE": null,
+		"POSIX_REC_MAX_XFER_SIZE": null,
+		"POSIX_REC_MIN_XFER_SIZE": 4096,
+		"POSIX_REC_XFER_ALIGN": 4096,
+		"SYMLINK_MAX": null,
+		"GNU_LIBC_VERSION": "glibc 2.23",
+		"GNU_LIBPTHREAD_VERSION": "NPTL 2.23",
+		"POSIX2_SYMLINKS": 1,
+		"LEVEL1_ICACHE_SIZE": 32768,
+		"LEVEL1_ICACHE_ASSOC": 8,
+		"LEVEL1_ICACHE_LINESIZE": 64,
+		"LEVEL1_DCACHE_SIZE": 32768,
+		"LEVEL1_DCACHE_ASSOC": 8,
+		"LEVEL1_DCACHE_LINESIZE": 64,
+		"LEVEL2_CACHE_SIZE": 262144,
+		"LEVEL2_CACHE_ASSOC": 8,
+		"LEVEL2_CACHE_LINESIZE": 64,
+		"LEVEL3_CACHE_SIZE": 31457280,
+		"LEVEL3_CACHE_ASSOC": 20,
+		"LEVEL3_CACHE_LINESIZE": 64,
+		"LEVEL4_CACHE_SIZE": 0,
+		"LEVEL4_CACHE_ASSOC": 0,
+		"LEVEL4_CACHE_LINESIZE": 0,
+		"IPV6": 200809,
+		"RAW_SOCKETS": 200809,
+		"_POSIX_IPV6": 200809,
+		"_POSIX_RAW_SOCKETS": 200809
+	},
+	"systemd_paths": {
+		"temporary": "/tmp",
+		"temporary-large": "/var/tmp",
+		"system-binaries": "/usr/bin",
+		"system-include": "/usr/include",
+		"system-library-private": "/usr/lib",
+		"system-library-arch": "/usr/lib/x86_64-linux-gnu",
+		"system-shared": "/usr/share",
+		"system-configuration-factory": "/usr/share/factory/etc",
+		"system-state-factory": "/usr/share/factory/var",
+		"system-configuration": "/etc",
+		"system-runtime": "/run",
+		"system-runtime-logs": "/run/log",
+		"system-state-private": "/var/lib",
+		"system-state-logs": "/var/log",
+		"system-state-cache": "/var/cache",
+		"system-state-spool": "/var/spool",
+		"user-binaries": "/home/ubuntu/.local/bin",
+		"user-library-private": "/home/ubuntu/.local/lib",
+		"user-library-arch": "/home/ubuntu/.local/lib/x86_64-linux-gnu",
+		"user-shared": "/home/ubuntu/.local/share",
+		"user-configuration": "/home/ubuntu/.config",
+		"user-runtime": "/run/user/1000",
+		"user-state-cache": "/home/ubuntu/.cache",
+		"user": "/home/ubuntu",
+		"user-documents": "/home/ubuntu",
+		"user-music": "/home/ubuntu",
+		"user-pictures": "/home/ubuntu",
+		"user-videos": "/home/ubuntu",
+		"user-download": "/home/ubuntu",
+		"user-public": "/home/ubuntu",
+		"user-templates": "/home/ubuntu",
+		"user-desktop": "/home/ubuntu/Desktop",
+		"search-binaries": "/home/ubuntu/bin",
+		"search-library-private": "/home/ubuntu/.local/lib",
+		"search-library-arch": "/home/ubuntu/.local/lib/x86_64-linux-gnu",
+		"search-shared": "/home/ubuntu/.local/share",
+		"search-configuration-factory": "/usr/local/share/factory/etc",
+		"search-state-factory": "/usr/local/share/factory/var",
+		"search-configuration": "/home/ubuntu/.config"
+	},
+	"time": {
+		"timezone": "UTC"
+	},
+	"uptime": "59 seconds",
+	"uptime_seconds": 59,
+	"virtualization": {
+		"systems": {
+			"xen": "guest"
+		},
+		"system": "xen",
+		"role": "guest"
+	}
+}

--- a/scans/ubuntu-ec2-train.json
+++ b/scans/ubuntu-ec2-train.json
@@ -1,0 +1,4605 @@
+{
+	"backend": null,
+	"block_device": {
+		"loop0": {
+			"size": "186344",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop1": {
+			"size": "36744",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop2": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop3": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop4": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop5": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop6": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"loop7": {
+			"size": "0",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		},
+		"ram0": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram1": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram10": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram11": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram12": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram13": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram14": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram15": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram2": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram3": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram4": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram5": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram6": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram7": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram8": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"ram9": {
+			"size": "131072",
+			"removable": "0",
+			"rotational": "1",
+			"physical_block_size": "4096",
+			"logical_block_size": "512"
+		},
+		"xvda": {
+			"size": "16777216",
+			"removable": "0",
+			"rotational": "0",
+			"physical_block_size": "512",
+			"logical_block_size": "512"
+		}
+	},
+	"chef_packages": {
+		"ohai": {
+			"version": "15.0.30",
+			"ohai_root": "/Users/franklinwebber/src/ohai/lib/ohai"
+		}
+	},
+	"cloud": {
+		"public_ipv4_addrs": [
+			"54.226.153.164"
+		],
+		"local_ipv4_addrs": [
+			"172.30.0.152"
+		],
+		"provider": "ec2",
+		"public_hostname": "",
+		"local_hostname": "ip-172-30-0-152.ec2.internal",
+		"public_ipv4": "54.226.153.164",
+		"local_ipv4": "172.30.0.152"
+	},
+	"command": {
+		"ps": "ps -ef"
+	},
+	"counters": {
+		"network": {
+			"interfaces": {
+				"lo": {
+					"tx": {
+						"queuelen": "1",
+						"bytes": "14456",
+						"packets": "192",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "14456",
+						"packets": "192",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				},
+				"eth0": {
+					"tx": {
+						"queuelen": "1000",
+						"bytes": "134131",
+						"packets": "1036",
+						"errors": "0",
+						"drop": "0",
+						"carrier": "0",
+						"collisions": "0"
+					},
+					"rx": {
+						"bytes": "569521",
+						"packets": "1115",
+						"errors": "0",
+						"drop": "0",
+						"overrun": "0"
+					}
+				}
+			}
+		}
+	},
+	"cpu": {
+		"0": {
+			"vendor_id": "GenuineIntel",
+			"family": "6",
+			"model": "63",
+			"model_name": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz",
+			"stepping": "2",
+			"mhz": "2400.088",
+			"cache_size": "30720 KB",
+			"physical_id": "0",
+			"core_id": "0",
+			"cores": "1",
+			"flags": [
+				"fpu",
+				"vme",
+				"de",
+				"pse",
+				"tsc",
+				"msr",
+				"pae",
+				"mce",
+				"cx8",
+				"apic",
+				"sep",
+				"mtrr",
+				"pge",
+				"mca",
+				"cmov",
+				"pat",
+				"pse36",
+				"clflush",
+				"mmx",
+				"fxsr",
+				"sse",
+				"sse2",
+				"ht",
+				"syscall",
+				"nx",
+				"rdtscp",
+				"lm",
+				"constant_tsc",
+				"rep_good",
+				"nopl",
+				"xtopology",
+				"pni",
+				"pclmulqdq",
+				"ssse3",
+				"fma",
+				"cx16",
+				"pcid",
+				"sse4_1",
+				"sse4_2",
+				"x2apic",
+				"movbe",
+				"popcnt",
+				"tsc_deadline_timer",
+				"aes",
+				"xsave",
+				"avx",
+				"f16c",
+				"rdrand",
+				"hypervisor",
+				"lahf_lm",
+				"abm",
+				"invpcid_single",
+				"kaiser",
+				"fsgsbase",
+				"bmi1",
+				"avx2",
+				"smep",
+				"bmi2",
+				"erms",
+				"invpcid",
+				"xsaveopt"
+			]
+		},
+		"total": 1,
+		"real": 1,
+		"cores": 1
+	},
+	"current_user": "ubuntu",
+	"dmi": {
+		"dmidecode_version": "3.0"
+	},
+	"docker": {},
+	"domain": null,
+	"ec2": {
+		"ami_id": "ami-0565af6e282977273",
+		"ami_launch_index": "0",
+		"ami_manifest_path": "(unknown)",
+		"block_device_mapping_ami": "/dev/sda1",
+		"block_device_mapping_root": "/dev/sda1",
+		"hostname": "ip-172-30-0-152.ec2.internal",
+		"instance_action": "none",
+		"instance_id": "i-0e520d7d9edafbe68",
+		"instance_type": "t2.micro",
+		"local_hostname": "ip-172-30-0-152.ec2.internal",
+		"local_ipv4": "172.30.0.152",
+		"mac": "0a:a3:fe:6c:de:9e",
+		"metrics_vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+		"network_interfaces_macs": {
+			"0a:a3:fe:6c:de:9e": {
+				"device_number": "0",
+				"interface_id": "eni-02654d490c2488e34",
+				"ipv4-associations": {
+					"54.226.153.164": "172.30.0.152"
+				},
+				"local_hostname": "ip-172-30-0-152.ec2.internal",
+				"local_ipv4s": "172.30.0.152",
+				"mac": "0a:a3:fe:6c:de:9e",
+				"owner_id": "399524901138",
+				"public_hostname": "",
+				"public_ipv4s": "54.226.153.164",
+				"security_group_ids": "sg-c7086ca3",
+				"security_groups": "launch-wizard-1",
+				"subnet_id": "subnet-49b5d63e",
+				"subnet_ipv4_cidr_block": "172.30.0.0/24",
+				"vpc_id": "vpc-02550367",
+				"vpc_ipv4_cidr_block": "172.30.0.0/16",
+				"vpc_ipv4_cidr_blocks": "172.30.0.0/16"
+			}
+		},
+		"placement_availability_zone": "us-east-1a",
+		"profile": "default-hvm",
+		"public_hostname": "",
+		"public_ipv4": "54.226.153.164",
+		"public_keys_0_openssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiezJPkkl7W6lXMfl3x7oEs6ahrR8W35zLGxQRsnq99ShKpZnB+X20wlskUQt8PpXE+3rersJwA8euF5lTiml53K/ojM190FZAiwgvYjLe0yB/mtP8nPzh5h2G6U6Iu7eNV0C2f+rzvzy7LM8W6t8ULpS+W48Va2teVD7927BMwWVzL1g4iLRvRnOHpYkVlO9KbzUzO2mDW8giT8tRQyc7hDBiJClLxxr+hUu7i/8Rfq2esTp2aXRyvpVycfExTKGotVcLYd4+f3VH2Lmf4mR5SckGXGyym/VUOl6uaRDoTijTaf3DDL3sZiZBTEdihGidt3hlysbum2HfWKfxbGgr ohai",
+		"reservation_id": "r-07399c1aa037f694e",
+		"security_groups": [
+			"launch-wizard-1"
+		],
+		"services_domain": "amazonaws.com",
+		"services_partition": "aws",
+		"userdata": null,
+		"account_id": "399524901138",
+		"availability_zone": "us-east-1a",
+		"region": "us-east-1"
+	},
+	"etc": {
+		"passwd": {
+			"root": {
+				"dir": "/root",
+				"gid": "0",
+				"uid": "0",
+				"shell": "/bin/bash",
+				"gecos": "root"
+			},
+			"daemon": {
+				"dir": "/usr/sbin",
+				"gid": "1",
+				"uid": "1",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "daemon"
+			},
+			"bin": {
+				"dir": "/bin",
+				"gid": "2",
+				"uid": "2",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "bin"
+			},
+			"sys": {
+				"dir": "/dev",
+				"gid": "3",
+				"uid": "3",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "sys"
+			},
+			"sync": {
+				"dir": "/bin",
+				"gid": "65534",
+				"uid": "4",
+				"shell": "/bin/sync",
+				"gecos": "sync"
+			},
+			"games": {
+				"dir": "/usr/games",
+				"gid": "60",
+				"uid": "5",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "games"
+			},
+			"man": {
+				"dir": "/var/cache/man",
+				"gid": "12",
+				"uid": "6",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "man"
+			},
+			"lp": {
+				"dir": "/var/spool/lpd",
+				"gid": "7",
+				"uid": "7",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "lp"
+			},
+			"mail": {
+				"dir": "/var/mail",
+				"gid": "8",
+				"uid": "8",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "mail"
+			},
+			"news": {
+				"dir": "/var/spool/news",
+				"gid": "9",
+				"uid": "9",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "news"
+			},
+			"uucp": {
+				"dir": "/var/spool/uucp",
+				"gid": "10",
+				"uid": "10",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "uucp"
+			},
+			"proxy": {
+				"dir": "/bin",
+				"gid": "13",
+				"uid": "13",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "proxy"
+			},
+			"www-data": {
+				"dir": "/var/www",
+				"gid": "33",
+				"uid": "33",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "www-data"
+			},
+			"backup": {
+				"dir": "/var/backups",
+				"gid": "34",
+				"uid": "34",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "backup"
+			},
+			"list": {
+				"dir": "/var/list",
+				"gid": "38",
+				"uid": "38",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "Mailing List Manager"
+			},
+			"irc": {
+				"dir": "/var/run/ircd",
+				"gid": "39",
+				"uid": "39",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "ircd"
+			},
+			"gnats": {
+				"dir": "/var/lib/gnats",
+				"gid": "41",
+				"uid": "41",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "Gnats Bug-Reporting System (admin)"
+			},
+			"nobody": {
+				"dir": "/nonexistent",
+				"gid": "65534",
+				"uid": "65534",
+				"shell": "/usr/sbin/nologin",
+				"gecos": "nobody"
+			},
+			"systemd-timesync": {
+				"dir": "/run/systemd",
+				"gid": "102",
+				"uid": "100",
+				"shell": "/bin/false",
+				"gecos": "systemd Time Synchronization,,,"
+			},
+			"systemd-network": {
+				"dir": "/run/systemd/netif",
+				"gid": "103",
+				"uid": "101",
+				"shell": "/bin/false",
+				"gecos": "systemd Network Management,,,"
+			},
+			"systemd-resolve": {
+				"dir": "/run/systemd/resolve",
+				"gid": "104",
+				"uid": "102",
+				"shell": "/bin/false",
+				"gecos": "systemd Resolver,,,"
+			},
+			"systemd-bus-proxy": {
+				"dir": "/run/systemd",
+				"gid": "105",
+				"uid": "103",
+				"shell": "/bin/false",
+				"gecos": "systemd Bus Proxy,,,"
+			},
+			"syslog": {
+				"dir": "/home/syslog",
+				"gid": "108",
+				"uid": "104",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"_apt": {
+				"dir": "/nonexistent",
+				"gid": "65534",
+				"uid": "105",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"lxd": {
+				"dir": "/var/lib/lxd/",
+				"gid": "65534",
+				"uid": "106",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"messagebus": {
+				"dir": "/var/run/dbus",
+				"gid": "111",
+				"uid": "107",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"uuidd": {
+				"dir": "/run/uuidd",
+				"gid": "112",
+				"uid": "108",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"dnsmasq": {
+				"dir": "/var/lib/misc",
+				"gid": "65534",
+				"uid": "109",
+				"shell": "/bin/false",
+				"gecos": "dnsmasq,,,"
+			},
+			"sshd": {
+				"dir": "/var/run/sshd",
+				"gid": "65534",
+				"uid": "110",
+				"shell": "/usr/sbin/nologin",
+				"gecos": ""
+			},
+			"pollinate": {
+				"dir": "/var/cache/pollinate",
+				"gid": "1",
+				"uid": "111",
+				"shell": "/bin/false",
+				"gecos": ""
+			},
+			"ubuntu": {
+				"dir": "/home/ubuntu",
+				"gid": "1000",
+				"uid": "1000",
+				"shell": "/bin/bash",
+				"gecos": "Ubuntu"
+			}
+		},
+		"group": {
+			"root": {
+				"gid": "0",
+				"members": []
+			},
+			"daemon": {
+				"gid": "1",
+				"members": []
+			},
+			"bin": {
+				"gid": "2",
+				"members": []
+			},
+			"sys": {
+				"gid": "3",
+				"members": []
+			},
+			"adm": {
+				"gid": "4",
+				"members": [
+					"syslog",
+					"ubuntu"
+				]
+			},
+			"tty": {
+				"gid": "5",
+				"members": []
+			},
+			"disk": {
+				"gid": "6",
+				"members": []
+			},
+			"lp": {
+				"gid": "7",
+				"members": []
+			},
+			"mail": {
+				"gid": "8",
+				"members": []
+			},
+			"news": {
+				"gid": "9",
+				"members": []
+			},
+			"uucp": {
+				"gid": "10",
+				"members": []
+			},
+			"man": {
+				"gid": "12",
+				"members": []
+			},
+			"proxy": {
+				"gid": "13",
+				"members": []
+			},
+			"kmem": {
+				"gid": "15",
+				"members": []
+			},
+			"dialout": {
+				"gid": "20",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"fax": {
+				"gid": "21",
+				"members": []
+			},
+			"voice": {
+				"gid": "22",
+				"members": []
+			},
+			"cdrom": {
+				"gid": "24",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"floppy": {
+				"gid": "25",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"tape": {
+				"gid": "26",
+				"members": []
+			},
+			"sudo": {
+				"gid": "27",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"audio": {
+				"gid": "29",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"dip": {
+				"gid": "30",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"www-data": {
+				"gid": "33",
+				"members": []
+			},
+			"backup": {
+				"gid": "34",
+				"members": []
+			},
+			"operator": {
+				"gid": "37",
+				"members": []
+			},
+			"list": {
+				"gid": "38",
+				"members": []
+			},
+			"irc": {
+				"gid": "39",
+				"members": []
+			},
+			"src": {
+				"gid": "40",
+				"members": []
+			},
+			"gnats": {
+				"gid": "41",
+				"members": []
+			},
+			"shadow": {
+				"gid": "42",
+				"members": []
+			},
+			"utmp": {
+				"gid": "43",
+				"members": []
+			},
+			"video": {
+				"gid": "44",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"sasl": {
+				"gid": "45",
+				"members": []
+			},
+			"plugdev": {
+				"gid": "46",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"staff": {
+				"gid": "50",
+				"members": []
+			},
+			"games": {
+				"gid": "60",
+				"members": []
+			},
+			"users": {
+				"gid": "100",
+				"members": []
+			},
+			"nogroup": {
+				"gid": "65534",
+				"members": []
+			},
+			"systemd-journal": {
+				"gid": "101",
+				"members": []
+			},
+			"systemd-timesync": {
+				"gid": "102",
+				"members": []
+			},
+			"systemd-network": {
+				"gid": "103",
+				"members": []
+			},
+			"systemd-resolve": {
+				"gid": "104",
+				"members": []
+			},
+			"systemd-bus-proxy": {
+				"gid": "105",
+				"members": []
+			},
+			"input": {
+				"gid": "106",
+				"members": []
+			},
+			"crontab": {
+				"gid": "107",
+				"members": []
+			},
+			"syslog": {
+				"gid": "108",
+				"members": []
+			},
+			"netdev": {
+				"gid": "109",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"lxd": {
+				"gid": "110",
+				"members": [
+					"ubuntu"
+				]
+			},
+			"messagebus": {
+				"gid": "111",
+				"members": []
+			},
+			"uuidd": {
+				"gid": "112",
+				"members": []
+			},
+			"ssh": {
+				"gid": "113",
+				"members": []
+			},
+			"mlocate": {
+				"gid": "114",
+				"members": []
+			},
+			"admin": {
+				"gid": "115",
+				"members": []
+			},
+			"ubuntu": {
+				"gid": "1000",
+				"members": []
+			}
+		}
+	},
+	"filesystem": {
+		"by_device": {
+			"udev": {
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				],
+				"mounts": [
+					"/dev"
+				]
+			},
+			"tmpfs": {
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				],
+				"mounts": [
+					"/run",
+					"/dev/shm",
+					"/run/lock",
+					"/sys/fs/cgroup",
+					"/run/user/1000"
+				]
+			},
+			"/dev/xvda1": {
+				"kb_size": "8065444",
+				"kb_used": "1154124",
+				"kb_available": "6894936",
+				"percent_used": "15%",
+				"total_inodes": "1024000",
+				"inodes_used": "73359",
+				"inodes_available": "950641",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs",
+				"mounts": [
+					"/"
+				]
+			},
+			"/dev/loop0": {
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"mounts": [
+					"/snap/core/6350"
+				]
+			},
+			"/dev/loop1": {
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"mounts": [
+					"/snap/amazon-ssm-agent/930"
+				]
+			},
+			"sysfs": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys"
+				]
+			},
+			"proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/proc"
+				]
+			},
+			"devpts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				],
+				"mounts": [
+					"/dev/pts"
+				]
+			},
+			"securityfs": {
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/kernel/security"
+				]
+			},
+			"cgroup": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				],
+				"mounts": [
+					"/sys/fs/cgroup/systemd",
+					"/sys/fs/cgroup/blkio",
+					"/sys/fs/cgroup/devices",
+					"/sys/fs/cgroup/net_cls,net_prio",
+					"/sys/fs/cgroup/cpuset",
+					"/sys/fs/cgroup/freezer",
+					"/sys/fs/cgroup/cpu,cpuacct",
+					"/sys/fs/cgroup/perf_event",
+					"/sys/fs/cgroup/pids",
+					"/sys/fs/cgroup/memory",
+					"/sys/fs/cgroup/hugetlb"
+				]
+			},
+			"pstore": {
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/fs/pstore"
+				]
+			},
+			"systemd-1": {
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				],
+				"mounts": [
+					"/proc/sys/fs/binfmt_misc"
+				]
+			},
+			"hugetlbfs": {
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/dev/hugepages"
+				]
+			},
+			"mqueue": {
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/dev/mqueue"
+				]
+			},
+			"debugfs": {
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/kernel/debug"
+				]
+			},
+			"fusectl": {
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"mounts": [
+					"/sys/fs/fuse/connections"
+				]
+			},
+			"lxcfs": {
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				],
+				"mounts": [
+					"/var/lib/lxcfs"
+				]
+			},
+			"/var/lib/snapd/snaps/core_6350.snap": {
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				],
+				"mounts": [
+					"/snap/core/6350"
+				]
+			},
+			"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap": {
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				],
+				"mounts": [
+					"/snap/amazon-ssm-agent/930"
+				]
+			},
+			"/dev/xvda": {
+				"mounts": []
+			}
+		},
+		"by_mountpoint": {
+			"/dev": {
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				],
+				"devices": [
+					"udev"
+				]
+			},
+			"/run": {
+				"kb_size": "101444",
+				"kb_used": "3324",
+				"kb_available": "98120",
+				"percent_used": "4%",
+				"total_inodes": "126804",
+				"inodes_used": "414",
+				"inodes_available": "126390",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"size=101444k",
+					"mode=755"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/": {
+				"kb_size": "8065444",
+				"kb_used": "1154124",
+				"kb_available": "6894936",
+				"percent_used": "15%",
+				"total_inodes": "1024000",
+				"inodes_used": "73359",
+				"inodes_available": "950641",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs",
+				"devices": [
+					"/dev/xvda1"
+				]
+			},
+			"/dev/shm": {
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "1",
+				"inodes_available": "126803",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/run/lock": {
+				"kb_size": "5120",
+				"kb_used": "0",
+				"kb_available": "5120",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "3",
+				"inodes_available": "126801",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"size=5120k"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/sys/fs/cgroup": {
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "16",
+				"inodes_available": "126788",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"ro",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"mode=755"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/run/user/1000": {
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				],
+				"devices": [
+					"tmpfs"
+				]
+			},
+			"/snap/core/6350": {
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"devices": [
+					"/dev/loop0",
+					"/var/lib/snapd/snaps/core_6350.snap"
+				],
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/snap/amazon-ssm-agent/930": {
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs",
+				"devices": [
+					"/dev/loop1",
+					"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap"
+				],
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/sys": {
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"sysfs"
+				]
+			},
+			"/proc": {
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"proc"
+				]
+			},
+			"/dev/pts": {
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				],
+				"devices": [
+					"devpts"
+				]
+			},
+			"/sys/kernel/security": {
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"securityfs"
+				]
+			},
+			"/sys/fs/cgroup/systemd": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"xattr",
+					"release_agent=/lib/systemd/systemd-cgroups-agent",
+					"name=systemd"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/pstore": {
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				],
+				"devices": [
+					"pstore"
+				]
+			},
+			"/sys/fs/cgroup/blkio": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"blkio"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/devices": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"devices"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/net_cls,net_prio": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"net_cls",
+					"net_prio"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/cpuset": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpuset"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/freezer": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"freezer"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/cpu,cpuacct": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpu",
+					"cpuacct"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/perf_event": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"perf_event"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/pids": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"pids"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/memory": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"memory"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/sys/fs/cgroup/hugetlb": {
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				],
+				"devices": [
+					"cgroup"
+				]
+			},
+			"/proc/sys/fs/binfmt_misc": {
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				],
+				"devices": [
+					"systemd-1"
+				]
+			},
+			"/dev/hugepages": {
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"hugetlbfs"
+				]
+			},
+			"/dev/mqueue": {
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"mqueue"
+				]
+			},
+			"/sys/kernel/debug": {
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"debugfs"
+				]
+			},
+			"/sys/fs/fuse/connections": {
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				],
+				"devices": [
+					"fusectl"
+				]
+			},
+			"/var/lib/lxcfs": {
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				],
+				"devices": [
+					"lxcfs"
+				]
+			}
+		},
+		"by_pair": {
+			"udev,/dev": {
+				"device": "udev",
+				"kb_size": "499272",
+				"kb_used": "0",
+				"kb_available": "499272",
+				"percent_used": "0%",
+				"mount": "/dev",
+				"total_inodes": "124818",
+				"inodes_used": "322",
+				"inodes_available": "124496",
+				"inodes_percent_used": "1%",
+				"fs_type": "devtmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"relatime",
+					"size=499272k",
+					"nr_inodes=124818",
+					"mode=755"
+				]
+			},
+			"tmpfs,/run": {
+				"device": "tmpfs",
+				"kb_size": "101444",
+				"kb_used": "3324",
+				"kb_available": "98120",
+				"percent_used": "4%",
+				"mount": "/run",
+				"total_inodes": "126804",
+				"inodes_used": "414",
+				"inodes_available": "126390",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"size=101444k",
+					"mode=755"
+				]
+			},
+			"/dev/xvda1,/": {
+				"device": "/dev/xvda1",
+				"kb_size": "8065444",
+				"kb_used": "1154124",
+				"kb_available": "6894936",
+				"percent_used": "15%",
+				"mount": "/",
+				"total_inodes": "1024000",
+				"inodes_used": "73359",
+				"inodes_available": "950641",
+				"inodes_percent_used": "8%",
+				"fs_type": "ext4",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"discard",
+					"data=ordered"
+				],
+				"uuid": "73e9659d-2fd9-46ca-a341-5a8637c416ee",
+				"label": "cloudimg-rootfs"
+			},
+			"tmpfs,/dev/shm": {
+				"device": "tmpfs",
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"mount": "/dev/shm",
+				"total_inodes": "126804",
+				"inodes_used": "1",
+				"inodes_available": "126803",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev"
+				]
+			},
+			"tmpfs,/run/lock": {
+				"device": "tmpfs",
+				"kb_size": "5120",
+				"kb_used": "0",
+				"kb_available": "5120",
+				"percent_used": "0%",
+				"mount": "/run/lock",
+				"total_inodes": "126804",
+				"inodes_used": "3",
+				"inodes_available": "126801",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"size=5120k"
+				]
+			},
+			"tmpfs,/sys/fs/cgroup": {
+				"device": "tmpfs",
+				"kb_size": "507216",
+				"kb_used": "0",
+				"kb_available": "507216",
+				"percent_used": "0%",
+				"mount": "/sys/fs/cgroup",
+				"total_inodes": "126804",
+				"inodes_used": "16",
+				"inodes_available": "126788",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"ro",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"mode=755"
+				]
+			},
+			"tmpfs,/run/user/1000": {
+				"device": "tmpfs",
+				"kb_size": "101444",
+				"kb_used": "0",
+				"kb_available": "101444",
+				"percent_used": "0%",
+				"mount": "/run/user/1000",
+				"total_inodes": "126804",
+				"inodes_used": "4",
+				"inodes_available": "126800",
+				"inodes_percent_used": "1%",
+				"fs_type": "tmpfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"size=101444k",
+					"mode=700",
+					"uid=1000",
+					"gid=1000"
+				]
+			},
+			"/dev/loop0,/snap/core/6350": {
+				"device": "/dev/loop0",
+				"kb_size": "93184",
+				"kb_used": "93184",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"mount": "/snap/core/6350",
+				"total_inodes": "12816",
+				"inodes_used": "12816",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs"
+			},
+			"/dev/loop1,/snap/amazon-ssm-agent/930": {
+				"device": "/dev/loop1",
+				"kb_size": "18432",
+				"kb_used": "18432",
+				"kb_available": "0",
+				"percent_used": "100%",
+				"mount": "/snap/amazon-ssm-agent/930",
+				"total_inodes": "15",
+				"inodes_used": "15",
+				"inodes_available": "0",
+				"inodes_percent_used": "100%",
+				"fs_type": "squashfs"
+			},
+			"sysfs,/sys": {
+				"device": "sysfs",
+				"mount": "/sys",
+				"fs_type": "sysfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"proc,/proc": {
+				"device": "proc",
+				"mount": "/proc",
+				"fs_type": "proc",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"devpts,/dev/pts": {
+				"device": "devpts",
+				"mount": "/dev/pts",
+				"fs_type": "devpts",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"noexec",
+					"relatime",
+					"gid=5",
+					"mode=620",
+					"ptmxmode=000"
+				]
+			},
+			"securityfs,/sys/kernel/security": {
+				"device": "securityfs",
+				"mount": "/sys/kernel/security",
+				"fs_type": "securityfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/systemd": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/systemd",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"xattr",
+					"release_agent=/lib/systemd/systemd-cgroups-agent",
+					"name=systemd"
+				]
+			},
+			"pstore,/sys/fs/pstore": {
+				"device": "pstore",
+				"mount": "/sys/fs/pstore",
+				"fs_type": "pstore",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/blkio": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/blkio",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"blkio"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/devices": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/devices",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"devices"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/net_cls,net_prio",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"net_cls",
+					"net_prio"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/cpuset": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/cpuset",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpuset"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/freezer": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/freezer",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"freezer"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/cpu,cpuacct",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"cpu",
+					"cpuacct"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/perf_event": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/perf_event",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"perf_event"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/pids": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/pids",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"pids"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/memory": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/memory",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"memory"
+				]
+			},
+			"cgroup,/sys/fs/cgroup/hugetlb": {
+				"device": "cgroup",
+				"mount": "/sys/fs/cgroup/hugetlb",
+				"fs_type": "cgroup",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"noexec",
+					"relatime",
+					"hugetlb"
+				]
+			},
+			"systemd-1,/proc/sys/fs/binfmt_misc": {
+				"device": "systemd-1",
+				"mount": "/proc/sys/fs/binfmt_misc",
+				"fs_type": "autofs",
+				"mount_options": [
+					"rw",
+					"relatime",
+					"fd=23",
+					"pgrp=1",
+					"timeout=0",
+					"minproto=5",
+					"maxproto=5",
+					"direct"
+				]
+			},
+			"hugetlbfs,/dev/hugepages": {
+				"device": "hugetlbfs",
+				"mount": "/dev/hugepages",
+				"fs_type": "hugetlbfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"mqueue,/dev/mqueue": {
+				"device": "mqueue",
+				"mount": "/dev/mqueue",
+				"fs_type": "mqueue",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"debugfs,/sys/kernel/debug": {
+				"device": "debugfs",
+				"mount": "/sys/kernel/debug",
+				"fs_type": "debugfs",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"fusectl,/sys/fs/fuse/connections": {
+				"device": "fusectl",
+				"mount": "/sys/fs/fuse/connections",
+				"fs_type": "fusectl",
+				"mount_options": [
+					"rw",
+					"relatime"
+				]
+			},
+			"lxcfs,/var/lib/lxcfs": {
+				"device": "lxcfs",
+				"mount": "/var/lib/lxcfs",
+				"fs_type": "fuse.lxcfs",
+				"mount_options": [
+					"rw",
+					"nosuid",
+					"nodev",
+					"relatime",
+					"user_id=0",
+					"group_id=0",
+					"allow_other"
+				]
+			},
+			"/var/lib/snapd/snaps/core_6350.snap,/snap/core/6350": {
+				"device": "/var/lib/snapd/snaps/core_6350.snap",
+				"mount": "/snap/core/6350",
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/var/lib/snapd/snaps/amazon-ssm-agent_930.snap,/snap/amazon-ssm-agent/930": {
+				"device": "/var/lib/snapd/snaps/amazon-ssm-agent_930.snap",
+				"mount": "/snap/amazon-ssm-agent/930",
+				"fs_type": "squashfs",
+				"mount_options": [
+					"ro",
+					"nodev",
+					"relatime"
+				]
+			},
+			"/dev/xvda,": {
+				"device": "/dev/xvda"
+			}
+		}
+	},
+	"fips": {
+		"kernel": {
+			"enabled": false
+		}
+	},
+	"hostname": "ip-172-30-0-152",
+	"hostnamectl": {
+		"static_hostname": "ip-172-30-0-152",
+		"icon_name": "computer-vm",
+		"chassis": "vm",
+		"machine_id": "369e1d700cb1486188eadb9969d1346b",
+		"boot_id": "9022ea316a854156bb86929f079aa2b2",
+		"virtualization": "xen",
+		"operating_system": "Ubuntu 16.04.5 LTS",
+		"kernel": "Linux 4.4.0-1075-aws",
+		"architecture": "x86-64"
+	},
+	"idletime": "01 seconds",
+	"idletime_seconds": 1,
+	"init_package": "systemd",
+	"ip6address": "fe80::8a3:feff:fe6c:de9e",
+	"ipaddress": "172.30.0.152",
+	"kernel": {
+		"name": "Linux",
+		"release": "4.4.0-1075-aws",
+		"version": "#85-Ubuntu SMP Thu Jan 17 17:15:12 UTC 2019",
+		"machine": "x86_64",
+		"processor": "x86_64",
+		"os": "GNU/Linux",
+		"modules": {
+			"serio_raw": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"ib_iser": {
+				"size": "49152",
+				"refcount": "0",
+				"version": "1.6"
+			},
+			"rdma_cm": {
+				"size": "49152",
+				"refcount": "1"
+			},
+			"iw_cm": {
+				"size": "45056",
+				"refcount": "1"
+			},
+			"ib_cm": {
+				"size": "49152",
+				"refcount": "1"
+			},
+			"ib_sa": {
+				"size": "36864",
+				"refcount": "2"
+			},
+			"ib_mad": {
+				"size": "49152",
+				"refcount": "2"
+			},
+			"ib_core": {
+				"size": "106496",
+				"refcount": "6"
+			},
+			"ib_addr": {
+				"size": "20480",
+				"refcount": "2"
+			},
+			"iscsi_tcp": {
+				"size": "20480",
+				"refcount": "0"
+			},
+			"libiscsi_tcp": {
+				"size": "24576",
+				"refcount": "1"
+			},
+			"libiscsi": {
+				"size": "53248",
+				"refcount": "3"
+			},
+			"scsi_transport_iscsi": {
+				"size": "102400",
+				"refcount": "4",
+				"version": "2.0-870"
+			},
+			"autofs4": {
+				"size": "40960",
+				"refcount": "2"
+			},
+			"btrfs": {
+				"size": "987136",
+				"refcount": "0"
+			},
+			"raid10": {
+				"size": "49152",
+				"refcount": "0"
+			},
+			"raid456": {
+				"size": "106496",
+				"refcount": "0"
+			},
+			"async_raid6_recov": {
+				"size": "20480",
+				"refcount": "1"
+			},
+			"async_memcpy": {
+				"size": "16384",
+				"refcount": "2"
+			},
+			"async_pq": {
+				"size": "16384",
+				"refcount": "2"
+			},
+			"async_xor": {
+				"size": "16384",
+				"refcount": "3"
+			},
+			"async_tx": {
+				"size": "16384",
+				"refcount": "5"
+			},
+			"xor": {
+				"size": "24576",
+				"refcount": "2"
+			},
+			"raid6_pq": {
+				"size": "102400",
+				"refcount": "4"
+			},
+			"libcrc32c": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"raid1": {
+				"size": "40960",
+				"refcount": "0"
+			},
+			"raid0": {
+				"size": "20480",
+				"refcount": "0"
+			},
+			"multipath": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"linear": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"crct10dif_pclmul": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"crc32_pclmul": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"ghash_clmulni_intel": {
+				"size": "16384",
+				"refcount": "0"
+			},
+			"aesni_intel": {
+				"size": "167936",
+				"refcount": "0"
+			},
+			"aes_x86_64": {
+				"size": "20480",
+				"refcount": "1"
+			},
+			"lrw": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"gf128mul": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"glue_helper": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"ablk_helper": {
+				"size": "16384",
+				"refcount": "1"
+			},
+			"cryptd": {
+				"size": "20480",
+				"refcount": "3"
+			}
+		}
+	},
+	"keys": {
+		"ssh": {
+			"host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC46AW9jrw6x3zRaWyd2+kj9173D4Xy0+PI/yGuR1Ca3hnFBusomDfjhKGT5WPJXgHQ2lO1t3nwRRjVeMDxJTyTqs/c0VRZCnXf99sQg8a9uHQQ0oX+3KDa0+OQqTEYvQVOmXx3227CBbEIJ7+YERAd0XDrtz8qTwc68x8m1NgMe3O9jYXu8hZIkBa5Sc1XrvRxjQe7gsBGsXRlgE5J7Esp5RuWjIxmDLU0qn24BGcN5tm8pI7tBPAjUi2Mwl7EtTsyHfd1hNVTmlFFg3cS7O1asKH4O5OTYFAB5NNxt9mK711sBFUM18iLn/52E80aWdG1MBszeoM4/m0hdSFg71QN",
+			"host_dsa_public": "AAAAB3NzaC1kc3MAAACBAP2NAZor8gVkt9B/uO4mDeBHU1tfxfLSOurUrsy+SZMEB9/W+Q2fFs647GH85uGjVcxUOXslje+27Ty54Pd8YRXFuBiMejHn67SQFu1Djjg6r3GNv91URZtivUQT8CF3n/iu4QBnFFcD6wcjo1JCHzj+3Ha3D/LrrQVuVk+KqluJAAAAFQDOLL5zcwhXV4bGeNIXlamBEE8AdwAAAIAQ2Qi3Ln163kIsYDHIjjvkQMgDhw4LiaGLKwZcJHM80PZmxQxo+l7owrWC4xQYL75Bm9s/gqomI8A+AeiwyvpXlMufFhSnIoD8tX9pPcuRbCu500P/PBSNvno1k8FETUIAQRI/P6zK+2msWM2+sAmXMKsQl96/jo/101HBsDrGfwAAAIEA97sEFMn2uUUxVyMp/kfgkkrdVRksBqRi/va2H6lZqWbbW/RCbBWkCrPVqAH3Ss6uUQm8CX9kSo9E8rJ5Apb5hNRdJFBE/PiIQo6a4sFNnx+aRc2SrFTqs6wPgnkQSMBpL0aaUNuJ29pNJ5+fWRfAJ+dubpkljY1zXZLXGm7QEY0=",
+			"host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL4w6eOLaCOjNJxP+iYePhKKqHi9rII57PjvVtrA5Ps/8ADdHcU7D1SkDLjr+go0LjgP4OBK8KxnV0x4VFI9neA=",
+			"host_ecdsa_type": "ecdsa-sha2-nistp256",
+			"host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIKk3Bqtw/Q1/9Ra90cSX5KL4hEUK3Pw0zpWyVH2HzUd1"
+		}
+	},
+	"languages": {
+		"ruby": {},
+		"perl": {
+			"version": "5.22.1",
+			"archname": "x86_64-linux-gnu-thread-multi"
+		}
+	},
+	"lsb": {
+		"id": "Ubuntu",
+		"description": "Ubuntu 16.04.5 LTS",
+		"release": "16.04",
+		"codename": "xenial"
+	},
+	"macaddress": "0A:A3:FE:6C:DE:9E",
+	"machine_id": "369e1d700cb1486188eadb9969d1346b",
+	"machinename": "ip-172-30-0-152",
+	"memory": {
+		"swap": {
+			"cached": "0kB",
+			"total": "0kB",
+			"free": "0kB"
+		},
+		"hugepages": {
+			"total": "0",
+			"free": "0",
+			"reserved": "0",
+			"surplus": "0"
+		},
+		"directmap": {
+			"4k": "36864kB",
+			"2M": "1011712kB"
+		},
+		"total": "1014436kB",
+		"free": "524844kB",
+		"available": "794232kB",
+		"buffers": "29108kB",
+		"cached": "364244kB",
+		"active": "152992kB",
+		"inactive": "271828kB",
+		"dirty": "16504kB",
+		"writeback": "0kB",
+		"anon_pages": "35084kB",
+		"mapped": "46236kB",
+		"slab": "38364kB",
+		"slab_reclaimable": "18988kB",
+		"slab_unreclaim": "19376kB",
+		"page_tables": "2952kB",
+		"nfs_unstable": "0kB",
+		"bounce": "0kB",
+		"commit_limit": "507216kB",
+		"committed_as": "283084kB",
+		"vmalloc_total": "34359738367kB",
+		"vmalloc_used": "0kB",
+		"vmalloc_chunk": "0kB",
+		"hugepage_size": "2048kB"
+	},
+	"network": {
+		"interfaces": {
+			"lo": {
+				"mtu": "65536",
+				"flags": [
+					"LOOPBACK",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Loopback",
+				"addresses": {
+					"127.0.0.1": {
+						"family": "inet",
+						"prefixlen": "8",
+						"netmask": "255.0.0.0",
+						"scope": "Node"
+					},
+					"::1": {
+						"family": "inet6",
+						"prefixlen": "128",
+						"scope": "Node",
+						"tags": []
+					}
+				},
+				"state": "unknown"
+			},
+			"eth0": {
+				"type": "eth",
+				"number": "0",
+				"mtu": "9001",
+				"flags": [
+					"BROADCAST",
+					"MULTICAST",
+					"UP",
+					"LOWER_UP"
+				],
+				"encapsulation": "Ethernet",
+				"addresses": {
+					"0A:A3:FE:6C:DE:9E": {
+						"family": "lladdr"
+					},
+					"172.30.0.152": {
+						"family": "inet",
+						"prefixlen": "24",
+						"netmask": "255.255.255.0",
+						"broadcast": "172.30.0.255",
+						"scope": "Global"
+					},
+					"fe80::8a3:feff:fe6c:de9e": {
+						"family": "inet6",
+						"prefixlen": "64",
+						"scope": "Link",
+						"tags": []
+					}
+				},
+				"state": "up",
+				"arp": {
+					"172.30.0.1": "0a:e7:37:d9:20:26",
+					"172.30.0.2": "0a:e7:37:d9:20:26"
+				},
+				"routes": [
+					{
+						"destination": "default",
+						"family": "inet",
+						"via": "172.30.0.1"
+					},
+					{
+						"destination": "172.30.0.0/24",
+						"family": "inet",
+						"scope": "link",
+						"proto": "kernel",
+						"src": "172.30.0.152"
+					},
+					{
+						"destination": "fe80::/64",
+						"family": "inet6",
+						"metric": "256",
+						"proto": "kernel"
+					}
+				],
+				"ring_params": {}
+			}
+		},
+		"default_interface": "eth0",
+		"default_gateway": "172.30.0.1"
+	},
+	"ohai_time": 1554351530.9332821,
+	"os": "linux",
+	"os_version": "4.4.0-1075-aws",
+	"packages": {
+		"accountsservice": {
+			"version": "0.6.40-2ubuntu11.3",
+			"arch": "amd64"
+		},
+		"acl": {
+			"version": "2.2.52-3",
+			"arch": "amd64"
+		},
+		"acpid": {
+			"version": "1:2.0.26-1ubuntu2",
+			"arch": "amd64"
+		},
+		"adduser": {
+			"version": "3.113+nmu3ubuntu4",
+			"arch": "all"
+		},
+		"apparmor": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"apport": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"apport-symptoms": {
+			"version": "0.20",
+			"arch": "all"
+		},
+		"apt": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"apt-transport-https": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"apt-utils": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"at": {
+			"version": "3.1.18-2ubuntu1",
+			"arch": "amd64"
+		},
+		"base-files": {
+			"version": "9.4ubuntu4.7",
+			"arch": "amd64"
+		},
+		"base-passwd": {
+			"version": "3.5.39",
+			"arch": "amd64"
+		},
+		"bash": {
+			"version": "4.3-14ubuntu1.2",
+			"arch": "amd64"
+		},
+		"bash-completion": {
+			"version": "1:2.1-4.2ubuntu1.1",
+			"arch": "all"
+		},
+		"bcache-tools": {
+			"version": "1.0.8-2",
+			"arch": "amd64"
+		},
+		"bind9-host": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"bsdmainutils": {
+			"version": "9.0.6ubuntu3",
+			"arch": "amd64"
+		},
+		"bsdutils": {
+			"version": "1:2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"btrfs-tools": {
+			"version": "4.4-1ubuntu1",
+			"arch": "amd64"
+		},
+		"busybox-initramfs": {
+			"version": "1:1.22.0-15ubuntu1",
+			"arch": "amd64"
+		},
+		"busybox-static": {
+			"version": "1:1.22.0-15ubuntu1",
+			"arch": "amd64"
+		},
+		"byobu": {
+			"version": "5.106-0ubuntu1",
+			"arch": "all"
+		},
+		"bzip2": {
+			"version": "1.0.6-8",
+			"arch": "amd64"
+		},
+		"ca-certificates": {
+			"version": "20170717~16.04.2",
+			"arch": "all"
+		},
+		"chef": {
+			"version": "14.11.21-1",
+			"arch": "amd64"
+		},
+		"cloud-guest-utils": {
+			"version": "0.27-0ubuntu25.1",
+			"arch": "all"
+		},
+		"cloud-init": {
+			"version": "18.4-0ubuntu1~16.04.2",
+			"arch": "all"
+		},
+		"cloud-initramfs-copymods": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"cloud-initramfs-dyn-netconf": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"command-not-found": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "all"
+		},
+		"command-not-found-data": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "amd64"
+		},
+		"console-setup": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"console-setup-linux": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"coreutils": {
+			"version": "8.25-2ubuntu3~16.04",
+			"arch": "amd64"
+		},
+		"cpio": {
+			"version": "2.11+dfsg-5ubuntu1",
+			"arch": "amd64"
+		},
+		"cron": {
+			"version": "3.0pl1-128ubuntu2",
+			"arch": "amd64"
+		},
+		"cryptsetup": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"cryptsetup-bin": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"curl": {
+			"version": "7.47.0-1ubuntu2.12",
+			"arch": "amd64"
+		},
+		"dash": {
+			"version": "0.5.8-2.1ubuntu2",
+			"arch": "amd64"
+		},
+		"dbus": {
+			"version": "1.10.6-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"debconf": {
+			"version": "1.5.58ubuntu1",
+			"arch": "all"
+		},
+		"debconf-i18n": {
+			"version": "1.5.58ubuntu1",
+			"arch": "all"
+		},
+		"debianutils": {
+			"version": "4.7",
+			"arch": "amd64"
+		},
+		"dh-python": {
+			"version": "2.20151103ubuntu1.1",
+			"arch": "all"
+		},
+		"diffutils": {
+			"version": "1:3.3-3",
+			"arch": "amd64"
+		},
+		"distro-info-data": {
+			"version": "0.28ubuntu0.9",
+			"arch": "all"
+		},
+		"dmeventd": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"dmidecode": {
+			"version": "3.0-2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"dmsetup": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"dns-root-data": {
+			"version": "2018013001~16.04.1",
+			"arch": "all"
+		},
+		"dnsmasq-base": {
+			"version": "2.75-1ubuntu0.16.04.5",
+			"arch": "amd64"
+		},
+		"dnsutils": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"dosfstools": {
+			"version": "3.0.28-2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"dpkg": {
+			"version": "1.18.4ubuntu1.5",
+			"arch": "amd64"
+		},
+		"e2fslibs": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"e2fsprogs": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"eatmydata": {
+			"version": "105-3",
+			"arch": "all"
+		},
+		"ed": {
+			"version": "1.10-2",
+			"arch": "amd64"
+		},
+		"eject": {
+			"version": "2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"ethtool": {
+			"version": "1:4.5-1",
+			"arch": "amd64"
+		},
+		"file": {
+			"version": "1:5.25-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"findutils": {
+			"version": "4.6.0+git+20160126-2",
+			"arch": "amd64"
+		},
+		"fonts-ubuntu-font-family-console": {
+			"version": "1:0.83-0ubuntu2",
+			"arch": "all"
+		},
+		"friendly-recovery": {
+			"version": "0.2.31ubuntu2",
+			"arch": "all"
+		},
+		"ftp": {
+			"version": "0.17-33",
+			"arch": "amd64"
+		},
+		"fuse": {
+			"version": "2.9.4-1ubuntu3.1",
+			"arch": "amd64"
+		},
+		"gawk": {
+			"version": "1:4.1.3+dfsg-0.1",
+			"arch": "amd64"
+		},
+		"gcc-5-base": {
+			"version": "5.4.0-6ubuntu1~16.04.11",
+			"arch": "amd64"
+		},
+		"gcc-6-base": {
+			"version": "6.0.1-0ubuntu1",
+			"arch": "amd64"
+		},
+		"gdisk": {
+			"version": "1.0.1-1build1",
+			"arch": "amd64"
+		},
+		"geoip-database": {
+			"version": "20160408-1",
+			"arch": "all"
+		},
+		"gettext-base": {
+			"version": "0.19.7-2ubuntu3.1",
+			"arch": "amd64"
+		},
+		"gir1.2-glib-2.0": {
+			"version": "1.46.0-3ubuntu1",
+			"arch": "amd64"
+		},
+		"git": {
+			"version": "1:2.7.4-0ubuntu1.6",
+			"arch": "amd64"
+		},
+		"git-man": {
+			"version": "1:2.7.4-0ubuntu1.6",
+			"arch": "all"
+		},
+		"gnupg": {
+			"version": "1.4.20-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"gpgv": {
+			"version": "1.4.20-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"grep": {
+			"version": "2.25-1~16.04.1",
+			"arch": "amd64"
+		},
+		"groff-base": {
+			"version": "1.22.3-7",
+			"arch": "amd64"
+		},
+		"grub-common": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub-gfxpayload-lists": {
+			"version": "0.7",
+			"arch": "amd64"
+		},
+		"grub-legacy-ec2": {
+			"version": "18.4-0ubuntu1~16.04.2",
+			"arch": "all"
+		},
+		"grub-pc": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub-pc-bin": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"grub2-common": {
+			"version": "2.02~beta2-36ubuntu3.20",
+			"arch": "amd64"
+		},
+		"gzip": {
+			"version": "1.6-4ubuntu1",
+			"arch": "amd64"
+		},
+		"hdparm": {
+			"version": "9.48+ds-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"hibagent": {
+			"version": "1.0.1-0ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"hostname": {
+			"version": "3.16ubuntu2",
+			"arch": "amd64"
+		},
+		"ifenslave": {
+			"version": "2.7ubuntu1",
+			"arch": "all"
+		},
+		"ifupdown": {
+			"version": "0.8.10ubuntu1.4",
+			"arch": "amd64"
+		},
+		"info": {
+			"version": "6.1.0.dfsg.1-5",
+			"arch": "amd64"
+		},
+		"init": {
+			"version": "1.29ubuntu4",
+			"arch": "amd64"
+		},
+		"init-system-helpers": {
+			"version": "1.29ubuntu4",
+			"arch": "all"
+		},
+		"initramfs-tools": {
+			"version": "0.122ubuntu8.14",
+			"arch": "all"
+		},
+		"initramfs-tools-bin": {
+			"version": "0.122ubuntu8.14",
+			"arch": "amd64"
+		},
+		"initramfs-tools-core": {
+			"version": "0.122ubuntu8.14",
+			"arch": "all"
+		},
+		"initscripts": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "amd64"
+		},
+		"insserv": {
+			"version": "1.14.0-5ubuntu3",
+			"arch": "amd64"
+		},
+		"install-info": {
+			"version": "6.1.0.dfsg.1-5",
+			"arch": "amd64"
+		},
+		"iproute2": {
+			"version": "4.3.0-1ubuntu3.16.04.4",
+			"arch": "amd64"
+		},
+		"iptables": {
+			"version": "1.6.0-2ubuntu3",
+			"arch": "amd64"
+		},
+		"iputils-ping": {
+			"version": "3:20121221-5ubuntu2",
+			"arch": "amd64"
+		},
+		"iputils-tracepath": {
+			"version": "3:20121221-5ubuntu2",
+			"arch": "amd64"
+		},
+		"irqbalance": {
+			"version": "1.1.0-2ubuntu1",
+			"arch": "amd64"
+		},
+		"isc-dhcp-client": {
+			"version": "4.3.3-5ubuntu12.10",
+			"arch": "amd64"
+		},
+		"isc-dhcp-common": {
+			"version": "4.3.3-5ubuntu12.10",
+			"arch": "amd64"
+		},
+		"iso-codes": {
+			"version": "3.65-1",
+			"arch": "all"
+		},
+		"kbd": {
+			"version": "1.15.5-1ubuntu5",
+			"arch": "amd64"
+		},
+		"keyboard-configuration": {
+			"version": "1.108ubuntu15.4",
+			"arch": "all"
+		},
+		"klibc-utils": {
+			"version": "2.0.4-8ubuntu1.16.04.4",
+			"arch": "amd64"
+		},
+		"kmod": {
+			"version": "22-1ubuntu5.1",
+			"arch": "amd64"
+		},
+		"krb5-locales": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "all"
+		},
+		"language-selector-common": {
+			"version": "0.165.4",
+			"arch": "all"
+		},
+		"less": {
+			"version": "481-2.1ubuntu0.2",
+			"arch": "amd64"
+		},
+		"libaccountsservice0": {
+			"version": "0.6.40-2ubuntu11.3",
+			"arch": "amd64"
+		},
+		"libacl1": {
+			"version": "2.2.52-3",
+			"arch": "amd64"
+		},
+		"libapparmor-perl": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"libapparmor1": {
+			"version": "2.10.95-0ubuntu2.10",
+			"arch": "amd64"
+		},
+		"libapt-inst2.0": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libapt-pkg5.0": {
+			"version": "1.2.29ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libasn1-8-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libasprintf0v5": {
+			"version": "0.19.7-2ubuntu3.1",
+			"arch": "amd64"
+		},
+		"libatm1": {
+			"version": "1:2.5.1-1.5",
+			"arch": "amd64"
+		},
+		"libattr1": {
+			"version": "1:2.4.47-2",
+			"arch": "amd64"
+		},
+		"libaudit-common": {
+			"version": "1:2.4.5-1ubuntu2.1",
+			"arch": "all"
+		},
+		"libaudit1": {
+			"version": "1:2.4.5-1ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libbind9-140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libblkid1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libbsd0": {
+			"version": "0.8.2-1",
+			"arch": "amd64"
+		},
+		"libbz2-1.0": {
+			"version": "1.0.6-8",
+			"arch": "amd64"
+		},
+		"libc-bin": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"libc6": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"libcap-ng0": {
+			"version": "0.7.7-1",
+			"arch": "amd64"
+		},
+		"libcap2": {
+			"version": "1:2.24-12",
+			"arch": "amd64"
+		},
+		"libcap2-bin": {
+			"version": "1:2.24-12",
+			"arch": "amd64"
+		},
+		"libcomerr2": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libcryptsetup4": {
+			"version": "2:1.6.6-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libcurl3-gnutls": {
+			"version": "7.47.0-1ubuntu2.12",
+			"arch": "amd64"
+		},
+		"libdb5.3": {
+			"version": "5.3.28-11ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libdbus-1-3": {
+			"version": "1.10.6-1ubuntu3.3",
+			"arch": "amd64"
+		},
+		"libdbus-glib-1-2": {
+			"version": "0.106-1",
+			"arch": "amd64"
+		},
+		"libdebconfclient0": {
+			"version": "0.198ubuntu1",
+			"arch": "amd64"
+		},
+		"libdevmapper-event1.02.1": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"libdevmapper1.02.1": {
+			"version": "2:1.02.110-1ubuntu10",
+			"arch": "amd64"
+		},
+		"libdns-export162": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libdns162": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libdrm-common": {
+			"version": "2.4.91-2~16.04.1",
+			"arch": "all"
+		},
+		"libdrm2": {
+			"version": "2.4.91-2~16.04.1",
+			"arch": "amd64"
+		},
+		"libdumbnet1": {
+			"version": "1.12-7",
+			"arch": "amd64"
+		},
+		"libeatmydata1": {
+			"version": "105-3",
+			"arch": "amd64"
+		},
+		"libedit2": {
+			"version": "3.1-20150325-1ubuntu2",
+			"arch": "amd64"
+		},
+		"libelf1": {
+			"version": "0.165-3ubuntu1.1",
+			"arch": "amd64"
+		},
+		"liberror-perl": {
+			"version": "0.17-1.2",
+			"arch": "all"
+		},
+		"libestr0": {
+			"version": "0.1.10-1",
+			"arch": "amd64"
+		},
+		"libevent-2.0-5": {
+			"version": "2.0.21-stable-2ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libexpat1": {
+			"version": "2.1.0-7ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libfdisk1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libffi6": {
+			"version": "3.2.1-4",
+			"arch": "amd64"
+		},
+		"libfreetype6": {
+			"version": "2.6.1-0.1ubuntu2.3",
+			"arch": "amd64"
+		},
+		"libfribidi0": {
+			"version": "0.19.7-1",
+			"arch": "amd64"
+		},
+		"libfuse2": {
+			"version": "2.9.4-1ubuntu3.1",
+			"arch": "amd64"
+		},
+		"libgcc1": {
+			"version": "1:6.0.1-0ubuntu1",
+			"arch": "amd64"
+		},
+		"libgcrypt20": {
+			"version": "1.6.5-2ubuntu0.5",
+			"arch": "amd64"
+		},
+		"libgdbm3": {
+			"version": "1.8.3-13.1",
+			"arch": "amd64"
+		},
+		"libgeoip1": {
+			"version": "1.6.9-1",
+			"arch": "amd64"
+		},
+		"libgirepository-1.0-1": {
+			"version": "1.46.0-3ubuntu1",
+			"arch": "amd64"
+		},
+		"libglib2.0-0": {
+			"version": "2.48.2-0ubuntu4.1",
+			"arch": "amd64"
+		},
+		"libglib2.0-data": {
+			"version": "2.48.2-0ubuntu4.1",
+			"arch": "all"
+		},
+		"libgmp10": {
+			"version": "2:6.1.0+dfsg-2",
+			"arch": "amd64"
+		},
+		"libgnutls-openssl27": {
+			"version": "3.4.10-4ubuntu1.4",
+			"arch": "amd64"
+		},
+		"libgnutls30": {
+			"version": "3.4.10-4ubuntu1.4",
+			"arch": "amd64"
+		},
+		"libgpg-error0": {
+			"version": "1.21-2ubuntu1",
+			"arch": "amd64"
+		},
+		"libgpm2": {
+			"version": "1.20.4-6.1",
+			"arch": "amd64"
+		},
+		"libgssapi-krb5-2": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libgssapi3-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libhcrypto4-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libheimbase1-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libheimntlm0-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libhogweed4": {
+			"version": "3.2-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libhx509-5-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libicu55": {
+			"version": "55.1-7ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libidn11": {
+			"version": "1.32-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"libisc-export160": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisc160": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisccc140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libisccfg140": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"libjson-c2": {
+			"version": "0.11-4ubuntu2",
+			"arch": "amd64"
+		},
+		"libk5crypto3": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libkeyutils1": {
+			"version": "1.5.9-8ubuntu1",
+			"arch": "amd64"
+		},
+		"libklibc": {
+			"version": "2.0.4-8ubuntu1.16.04.4",
+			"arch": "amd64"
+		},
+		"libkmod2": {
+			"version": "22-1ubuntu5.1",
+			"arch": "amd64"
+		},
+		"libkrb5-26-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libkrb5-3": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libkrb5support0": {
+			"version": "1.13.2+dfsg-5ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libldap-2.4-2": {
+			"version": "2.4.42+dfsg-2ubuntu3.4",
+			"arch": "amd64"
+		},
+		"liblocale-gettext-perl": {
+			"version": "1.07-1build1",
+			"arch": "amd64"
+		},
+		"liblvm2app2.2": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"liblvm2cmd2.02": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"liblwres141": {
+			"version": "1:9.10.3.dfsg.P4-8ubuntu1.11",
+			"arch": "amd64"
+		},
+		"liblxc1": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"liblz4-1": {
+			"version": "0.0~r131-2ubuntu2",
+			"arch": "amd64"
+		},
+		"liblzma5": {
+			"version": "5.1.1alpha+20120614-2ubuntu2",
+			"arch": "amd64"
+		},
+		"liblzo2-2": {
+			"version": "2.08-1.2",
+			"arch": "amd64"
+		},
+		"libmagic1": {
+			"version": "1:5.25-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libmnl0": {
+			"version": "1.0.3-5",
+			"arch": "amd64"
+		},
+		"libmount1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libmpdec2": {
+			"version": "2.4.2-1",
+			"arch": "amd64"
+		},
+		"libmpfr4": {
+			"version": "3.1.4-1",
+			"arch": "amd64"
+		},
+		"libmspack0": {
+			"version": "0.5-1ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libncurses5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libncursesw5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libnetfilter-conntrack3": {
+			"version": "1.0.5-1",
+			"arch": "amd64"
+		},
+		"libnettle6": {
+			"version": "3.2-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"libnewt0.52": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"libnfnetlink0": {
+			"version": "1.0.1-3",
+			"arch": "amd64"
+		},
+		"libnih1": {
+			"version": "1.0.3-4.3ubuntu1",
+			"arch": "amd64"
+		},
+		"libnuma1": {
+			"version": "2.0.11-1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libp11-kit0": {
+			"version": "0.23.2-5~ubuntu16.04.1",
+			"arch": "amd64"
+		},
+		"libpam-modules": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libpam-modules-bin": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libpam-runtime": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "all"
+		},
+		"libpam-systemd": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libpam0g": {
+			"version": "1.1.8-3.2ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libparted2": {
+			"version": "3.2-15ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libpcap0.8": {
+			"version": "1.7.4-2",
+			"arch": "amd64"
+		},
+		"libpci3": {
+			"version": "1:3.3.1-1.1ubuntu1.2",
+			"arch": "amd64"
+		},
+		"libpcre3": {
+			"version": "2:8.38-3.1",
+			"arch": "amd64"
+		},
+		"libperl5.22": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"libpipeline1": {
+			"version": "1.4.1-2",
+			"arch": "amd64"
+		},
+		"libplymouth4": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"libpng12-0": {
+			"version": "1.2.54-1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libpolkit-agent-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpolkit-backend-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpolkit-gobject-1-0": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"libpopt0": {
+			"version": "1.16-10",
+			"arch": "amd64"
+		},
+		"libprocps4": {
+			"version": "2:3.3.10-4ubuntu2.4",
+			"arch": "amd64"
+		},
+		"libpython3-stdlib": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"libpython3.5": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libpython3.5-minimal": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libpython3.5-stdlib": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"libreadline5": {
+			"version": "5.2+dfsg-3build1",
+			"arch": "amd64"
+		},
+		"libreadline6": {
+			"version": "6.3-8ubuntu2",
+			"arch": "amd64"
+		},
+		"libroken18-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"librtmp1": {
+			"version": "2.4+20151223.gitfa8646d-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-2": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-modules": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libsasl2-modules-db": {
+			"version": "2.1.26.dfsg1-14ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libseccomp2": {
+			"version": "2.3.1-2.1ubuntu2~16.04.1",
+			"arch": "amd64"
+		},
+		"libselinux1": {
+			"version": "2.4-3build2",
+			"arch": "amd64"
+		},
+		"libsemanage-common": {
+			"version": "2.3-1build3",
+			"arch": "all"
+		},
+		"libsemanage1": {
+			"version": "2.3-1build3",
+			"arch": "amd64"
+		},
+		"libsepol1": {
+			"version": "2.4-2",
+			"arch": "amd64"
+		},
+		"libsigsegv2": {
+			"version": "2.10-4",
+			"arch": "amd64"
+		},
+		"libslang2": {
+			"version": "2.3.0-2ubuntu1.1",
+			"arch": "amd64"
+		},
+		"libsmartcols1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libsqlite3-0": {
+			"version": "3.11.0-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libss2": {
+			"version": "1.42.13-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libssl1.0.0": {
+			"version": "1.0.2g-1ubuntu4.14",
+			"arch": "amd64"
+		},
+		"libstdc++6": {
+			"version": "5.4.0-6ubuntu1~16.04.11",
+			"arch": "amd64"
+		},
+		"libsystemd0": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libtasn1-6": {
+			"version": "4.7-3ubuntu0.16.04.3",
+			"arch": "amd64"
+		},
+		"libtext-charwidth-perl": {
+			"version": "0.04-7build5",
+			"arch": "amd64"
+		},
+		"libtext-iconv-perl": {
+			"version": "1.7-5build4",
+			"arch": "amd64"
+		},
+		"libtext-wrapi18n-perl": {
+			"version": "0.06-7.1",
+			"arch": "all"
+		},
+		"libtinfo5": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libudev1": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"libusb-0.1-4": {
+			"version": "2:0.1.12-28",
+			"arch": "amd64"
+		},
+		"libusb-1.0-0": {
+			"version": "2:1.0.20-1",
+			"arch": "amd64"
+		},
+		"libustr-1.0-1": {
+			"version": "1.0.4-5",
+			"arch": "amd64"
+		},
+		"libutempter0": {
+			"version": "1.1.6-3",
+			"arch": "amd64"
+		},
+		"libuuid1": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"libwind0-heimdal": {
+			"version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1",
+			"arch": "amd64"
+		},
+		"libwrap0": {
+			"version": "7.6.q-25",
+			"arch": "amd64"
+		},
+		"libx11-6": {
+			"version": "2:1.6.3-1ubuntu2.1",
+			"arch": "amd64"
+		},
+		"libx11-data": {
+			"version": "2:1.6.3-1ubuntu2.1",
+			"arch": "all"
+		},
+		"libxau6": {
+			"version": "1:1.0.8-1",
+			"arch": "amd64"
+		},
+		"libxcb1": {
+			"version": "1.11.1-1ubuntu1",
+			"arch": "amd64"
+		},
+		"libxdmcp6": {
+			"version": "1:1.1.2-1.1",
+			"arch": "amd64"
+		},
+		"libxext6": {
+			"version": "2:1.3.3-1",
+			"arch": "amd64"
+		},
+		"libxml2": {
+			"version": "2.9.3+dfsg1-1ubuntu0.6",
+			"arch": "amd64"
+		},
+		"libxmlsec1": {
+			"version": "1.2.20-2ubuntu4",
+			"arch": "amd64"
+		},
+		"libxmlsec1-openssl": {
+			"version": "1.2.20-2ubuntu4",
+			"arch": "amd64"
+		},
+		"libxmuu1": {
+			"version": "2:1.1.2-2",
+			"arch": "amd64"
+		},
+		"libxslt1.1": {
+			"version": "1.1.28-2.1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"libxtables11": {
+			"version": "1.6.0-2ubuntu3",
+			"arch": "amd64"
+		},
+		"libyaml-0-2": {
+			"version": "0.1.6-3",
+			"arch": "amd64"
+		},
+		"linux-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"linux-aws-headers-4.4.0-1075": {
+			"version": "4.4.0-1075.85",
+			"arch": "all"
+		},
+		"linux-base": {
+			"version": "4.5ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"linux-headers-4.4.0-1075-aws": {
+			"version": "4.4.0-1075.85",
+			"arch": "amd64"
+		},
+		"linux-headers-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"linux-image-4.4.0-1075-aws": {
+			"version": "4.4.0-1075.85",
+			"arch": "amd64"
+		},
+		"linux-image-aws": {
+			"version": "4.4.0.1075.77",
+			"arch": "amd64"
+		},
+		"locales": {
+			"version": "2.23-0ubuntu10",
+			"arch": "all"
+		},
+		"login": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"logrotate": {
+			"version": "3.8.7-2ubuntu2.16.04.2",
+			"arch": "amd64"
+		},
+		"lsb-base": {
+			"version": "9.20160110ubuntu0.2",
+			"arch": "all"
+		},
+		"lsb-release": {
+			"version": "9.20160110ubuntu0.2",
+			"arch": "all"
+		},
+		"lshw": {
+			"version": "02.17-1.1ubuntu3.5",
+			"arch": "amd64"
+		},
+		"lsof": {
+			"version": "4.89+dfsg-0.1",
+			"arch": "amd64"
+		},
+		"ltrace": {
+			"version": "0.7.3-5.1ubuntu4",
+			"arch": "amd64"
+		},
+		"lvm2": {
+			"version": "2.02.133-1ubuntu10",
+			"arch": "amd64"
+		},
+		"lxc-common": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"lxcfs": {
+			"version": "2.0.8-0ubuntu1~16.04.2",
+			"arch": "amd64"
+		},
+		"lxd": {
+			"version": "2.0.11-0ubuntu1~16.04.4",
+			"arch": "amd64"
+		},
+		"lxd-client": {
+			"version": "2.0.11-0ubuntu1~16.04.4",
+			"arch": "amd64"
+		},
+		"makedev": {
+			"version": "2.3.1-93ubuntu2~ubuntu16.04.1",
+			"arch": "all"
+		},
+		"man-db": {
+			"version": "2.7.5-1",
+			"arch": "amd64"
+		},
+		"manpages": {
+			"version": "4.04-2",
+			"arch": "all"
+		},
+		"mawk": {
+			"version": "1.3.3-17ubuntu2",
+			"arch": "amd64"
+		},
+		"mdadm": {
+			"version": "3.3-2ubuntu7.6",
+			"arch": "amd64"
+		},
+		"mime-support": {
+			"version": "3.59ubuntu1",
+			"arch": "all"
+		},
+		"mlocate": {
+			"version": "0.26-1ubuntu2",
+			"arch": "amd64"
+		},
+		"mount": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"mtr-tiny": {
+			"version": "0.86-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"multiarch-support": {
+			"version": "2.23-0ubuntu10",
+			"arch": "amd64"
+		},
+		"nano": {
+			"version": "2.5.3-2ubuntu2",
+			"arch": "amd64"
+		},
+		"ncurses-base": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "all"
+		},
+		"ncurses-bin": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "amd64"
+		},
+		"ncurses-term": {
+			"version": "6.0+20160213-1ubuntu1",
+			"arch": "all"
+		},
+		"net-tools": {
+			"version": "1.60-26ubuntu1",
+			"arch": "amd64"
+		},
+		"netbase": {
+			"version": "5.3",
+			"arch": "all"
+		},
+		"netcat-openbsd": {
+			"version": "1.105-7ubuntu1",
+			"arch": "amd64"
+		},
+		"ntfs-3g": {
+			"version": "1:2015.3.14AR.1-1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"open-iscsi": {
+			"version": "2.0.873+git0.3b4b4500-14ubuntu3.7",
+			"arch": "amd64"
+		},
+		"open-vm-tools": {
+			"version": "2:10.2.0-3~ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"openssh-client": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssh-server": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssh-sftp-server": {
+			"version": "1:7.2p2-4ubuntu2.7",
+			"arch": "amd64"
+		},
+		"openssl": {
+			"version": "1.0.2g-1ubuntu4.14",
+			"arch": "amd64"
+		},
+		"os-prober": {
+			"version": "1.70ubuntu3.3",
+			"arch": "amd64"
+		},
+		"overlayroot": {
+			"version": "0.27ubuntu1.6",
+			"arch": "all"
+		},
+		"parted": {
+			"version": "3.2-15ubuntu0.1",
+			"arch": "amd64"
+		},
+		"passwd": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"pastebinit": {
+			"version": "1.5-1",
+			"arch": "all"
+		},
+		"patch": {
+			"version": "2.7.5-1ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"pciutils": {
+			"version": "1:3.3.1-1.1ubuntu1.2",
+			"arch": "amd64"
+		},
+		"perl": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"perl-base": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "amd64"
+		},
+		"perl-modules-5.22": {
+			"version": "5.22.1-9ubuntu0.6",
+			"arch": "all"
+		},
+		"plymouth": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"plymouth-theme-ubuntu-text": {
+			"version": "0.9.2-3ubuntu13.5",
+			"arch": "amd64"
+		},
+		"policykit-1": {
+			"version": "0.105-14.1ubuntu0.4",
+			"arch": "amd64"
+		},
+		"pollinate": {
+			"version": "4.33-0ubuntu1~16.04.1",
+			"arch": "all"
+		},
+		"popularity-contest": {
+			"version": "1.64ubuntu2",
+			"arch": "all"
+		},
+		"powermgmt-base": {
+			"version": "1.31+nmu1",
+			"arch": "all"
+		},
+		"procps": {
+			"version": "2:3.3.10-4ubuntu2.4",
+			"arch": "amd64"
+		},
+		"psmisc": {
+			"version": "22.21-2.1build1",
+			"arch": "amd64"
+		},
+		"python-apt-common": {
+			"version": "1.1.0~beta1ubuntu0.16.04.2",
+			"arch": "all"
+		},
+		"python3": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"python3-apport": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"python3-apt": {
+			"version": "1.1.0~beta1ubuntu0.16.04.2",
+			"arch": "amd64"
+		},
+		"python3-blinker": {
+			"version": "1.3.dfsg2-1build1",
+			"arch": "all"
+		},
+		"python3-cffi-backend": {
+			"version": "1.5.2-1ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-chardet": {
+			"version": "2.3.0-2",
+			"arch": "all"
+		},
+		"python3-commandnotfound": {
+			"version": "0.3ubuntu16.04.2",
+			"arch": "all"
+		},
+		"python3-configobj": {
+			"version": "5.0.6-2",
+			"arch": "all"
+		},
+		"python3-cryptography": {
+			"version": "1.2.3-1ubuntu0.2",
+			"arch": "amd64"
+		},
+		"python3-dbus": {
+			"version": "1.2.0-3",
+			"arch": "amd64"
+		},
+		"python3-debian": {
+			"version": "0.1.27ubuntu2",
+			"arch": "all"
+		},
+		"python3-distupgrade": {
+			"version": "1:16.04.26",
+			"arch": "all"
+		},
+		"python3-gdbm": {
+			"version": "3.5.1-1",
+			"arch": "amd64"
+		},
+		"python3-gi": {
+			"version": "3.20.0-0ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-idna": {
+			"version": "2.0-3",
+			"arch": "all"
+		},
+		"python3-jinja2": {
+			"version": "2.8-1",
+			"arch": "all"
+		},
+		"python3-json-pointer": {
+			"version": "1.9-3",
+			"arch": "all"
+		},
+		"python3-jsonpatch": {
+			"version": "1.19-3",
+			"arch": "all"
+		},
+		"python3-jwt": {
+			"version": "1.3.0-1ubuntu0.1",
+			"arch": "all"
+		},
+		"python3-markupsafe": {
+			"version": "0.23-2build2",
+			"arch": "amd64"
+		},
+		"python3-minimal": {
+			"version": "3.5.1-3",
+			"arch": "amd64"
+		},
+		"python3-newt": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"python3-oauthlib": {
+			"version": "1.0.3-1",
+			"arch": "all"
+		},
+		"python3-pkg-resources": {
+			"version": "20.7.0-1",
+			"arch": "all"
+		},
+		"python3-prettytable": {
+			"version": "0.7.2-3",
+			"arch": "all"
+		},
+		"python3-problem-report": {
+			"version": "2.20.1-0ubuntu2.18",
+			"arch": "all"
+		},
+		"python3-pyasn1": {
+			"version": "0.1.9-1",
+			"arch": "all"
+		},
+		"python3-pycurl": {
+			"version": "7.43.0-1ubuntu1",
+			"arch": "amd64"
+		},
+		"python3-requests": {
+			"version": "2.9.1-3ubuntu0.1",
+			"arch": "all"
+		},
+		"python3-serial": {
+			"version": "3.0.1-1",
+			"arch": "all"
+		},
+		"python3-six": {
+			"version": "1.10.0-3",
+			"arch": "all"
+		},
+		"python3-software-properties": {
+			"version": "0.96.20.8",
+			"arch": "all"
+		},
+		"python3-systemd": {
+			"version": "231-2build1",
+			"arch": "amd64"
+		},
+		"python3-update-manager": {
+			"version": "1:16.04.15",
+			"arch": "all"
+		},
+		"python3-urllib3": {
+			"version": "1.13.1-2ubuntu0.16.04.2",
+			"arch": "all"
+		},
+		"python3-yaml": {
+			"version": "3.11-3build1",
+			"arch": "amd64"
+		},
+		"python3.5": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"python3.5-minimal": {
+			"version": "3.5.2-2ubuntu0~16.04.5",
+			"arch": "amd64"
+		},
+		"readline-common": {
+			"version": "6.3-8ubuntu2",
+			"arch": "all"
+		},
+		"rename": {
+			"version": "0.20-4",
+			"arch": "all"
+		},
+		"resolvconf": {
+			"version": "1.78ubuntu6",
+			"arch": "all"
+		},
+		"rsync": {
+			"version": "3.1.1-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"rsyslog": {
+			"version": "8.16.0-1ubuntu3",
+			"arch": "amd64"
+		},
+		"run-one": {
+			"version": "1.17-0ubuntu1",
+			"arch": "all"
+		},
+		"screen": {
+			"version": "4.3.1-2build1",
+			"arch": "amd64"
+		},
+		"sed": {
+			"version": "4.2.2-7",
+			"arch": "amd64"
+		},
+		"sensible-utils": {
+			"version": "0.0.9ubuntu0.16.04.1",
+			"arch": "all"
+		},
+		"sgml-base": {
+			"version": "1.26+nmu4ubuntu1",
+			"arch": "all"
+		},
+		"shared-mime-info": {
+			"version": "1.5-2ubuntu0.2",
+			"arch": "amd64"
+		},
+		"snapd": {
+			"version": "2.34.2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"software-properties-common": {
+			"version": "0.96.20.8",
+			"arch": "all"
+		},
+		"sosreport": {
+			"version": "3.6-1ubuntu0.16.04.2",
+			"arch": "amd64"
+		},
+		"squashfs-tools": {
+			"version": "1:4.3-3ubuntu2.16.04.3",
+			"arch": "amd64"
+		},
+		"ssh-import-id": {
+			"version": "5.5-0ubuntu1",
+			"arch": "all"
+		},
+		"strace": {
+			"version": "4.11-1ubuntu3",
+			"arch": "amd64"
+		},
+		"sudo": {
+			"version": "1.8.16-0ubuntu1.5",
+			"arch": "amd64"
+		},
+		"systemd": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"systemd-sysv": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"sysv-rc": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "all"
+		},
+		"sysvinit-utils": {
+			"version": "2.88dsf-59.3ubuntu2",
+			"arch": "amd64"
+		},
+		"tar": {
+			"version": "1.28-2.1ubuntu0.1",
+			"arch": "amd64"
+		},
+		"tcpd": {
+			"version": "7.6.q-25",
+			"arch": "amd64"
+		},
+		"tcpdump": {
+			"version": "4.9.2-0ubuntu0.16.04.1",
+			"arch": "amd64"
+		},
+		"telnet": {
+			"version": "0.17-40",
+			"arch": "amd64"
+		},
+		"time": {
+			"version": "1.7-25.1",
+			"arch": "amd64"
+		},
+		"tmux": {
+			"version": "2.1-3build1",
+			"arch": "amd64"
+		},
+		"tzdata": {
+			"version": "2018i-0ubuntu0.16.04",
+			"arch": "all"
+		},
+		"ubuntu-advantage-tools": {
+			"version": "10ubuntu0.16.04.1",
+			"arch": "all"
+		},
+		"ubuntu-cloudimage-keyring": {
+			"version": "2013.11.11",
+			"arch": "all"
+		},
+		"ubuntu-core-launcher": {
+			"version": "2.34.2ubuntu0.1",
+			"arch": "amd64"
+		},
+		"ubuntu-keyring": {
+			"version": "2012.05.19",
+			"arch": "all"
+		},
+		"ubuntu-minimal": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ubuntu-release-upgrader-core": {
+			"version": "1:16.04.26",
+			"arch": "all"
+		},
+		"ubuntu-server": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ubuntu-standard": {
+			"version": "1.361.2",
+			"arch": "amd64"
+		},
+		"ucf": {
+			"version": "3.0036",
+			"arch": "all"
+		},
+		"udev": {
+			"version": "229-4ubuntu21.15",
+			"arch": "amd64"
+		},
+		"ufw": {
+			"version": "0.35-0ubuntu2",
+			"arch": "all"
+		},
+		"uidmap": {
+			"version": "1:4.2-3.1ubuntu5.3",
+			"arch": "amd64"
+		},
+		"unattended-upgrades": {
+			"version": "0.90ubuntu0.10",
+			"arch": "all"
+		},
+		"update-manager-core": {
+			"version": "1:16.04.15",
+			"arch": "all"
+		},
+		"update-notifier-common": {
+			"version": "3.168.10",
+			"arch": "all"
+		},
+		"ureadahead": {
+			"version": "0.100.0-19",
+			"arch": "amd64"
+		},
+		"usbutils": {
+			"version": "1:007-4",
+			"arch": "amd64"
+		},
+		"util-linux": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"uuid-runtime": {
+			"version": "2.27.1-6ubuntu3.6",
+			"arch": "amd64"
+		},
+		"vim": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vim-common": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vim-runtime": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "all"
+		},
+		"vim-tiny": {
+			"version": "2:7.4.1689-3ubuntu1.2",
+			"arch": "amd64"
+		},
+		"vlan": {
+			"version": "1.9-3.2ubuntu1.16.04.5",
+			"arch": "amd64"
+		},
+		"wget": {
+			"version": "1.17.1-1ubuntu1.4",
+			"arch": "amd64"
+		},
+		"whiptail": {
+			"version": "0.52.18-1ubuntu2",
+			"arch": "amd64"
+		},
+		"xauth": {
+			"version": "1:1.0.9-1ubuntu2",
+			"arch": "amd64"
+		},
+		"xdg-user-dirs": {
+			"version": "0.15-2ubuntu6.16.04.1",
+			"arch": "amd64"
+		},
+		"xfsprogs": {
+			"version": "4.3.0+nmu1ubuntu1.1",
+			"arch": "amd64"
+		},
+		"xkb-data": {
+			"version": "2.16-1ubuntu1",
+			"arch": "all"
+		},
+		"xml-core": {
+			"version": "0.13+nmu2",
+			"arch": "all"
+		},
+		"xz-utils": {
+			"version": "5.1.1alpha+20120614-2ubuntu2",
+			"arch": "amd64"
+		},
+		"zerofree": {
+			"version": "1.0.3-1",
+			"arch": "amd64"
+		},
+		"zlib1g": {
+			"version": "1:1.2.8.dfsg-2ubuntu4.1",
+			"arch": "amd64"
+		}
+	},
+	"platform": "ubuntu",
+	"platform_family": "debian",
+	"platform_version": "16.04",
+	"root_group": "root",
+	"shard_seed": 163378034,
+	"shells": [
+		"/bin/sh",
+		"/bin/dash",
+		"/bin/bash",
+		"/bin/rbash",
+		"/usr/bin/tmux",
+		"/usr/bin/screen"
+	],
+	"sysconf": {
+		"LINK_MAX": 65000,
+		"_POSIX_LINK_MAX": 65000,
+		"MAX_CANON": 255,
+		"_POSIX_MAX_CANON": 255,
+		"MAX_INPUT": 255,
+		"_POSIX_MAX_INPUT": 255,
+		"NAME_MAX": 255,
+		"_POSIX_NAME_MAX": 255,
+		"PATH_MAX": 4096,
+		"_POSIX_PATH_MAX": 4096,
+		"PIPE_BUF": 4096,
+		"_POSIX_PIPE_BUF": 4096,
+		"SOCK_MAXBUF": null,
+		"_POSIX_ASYNC_IO": null,
+		"_POSIX_CHOWN_RESTRICTED": 1,
+		"_POSIX_NO_TRUNC": 1,
+		"_POSIX_PRIO_IO": null,
+		"_POSIX_SYNC_IO": null,
+		"_POSIX_VDISABLE": 0,
+		"ARG_MAX": 2097152,
+		"ATEXIT_MAX": 2147483647,
+		"CHAR_BIT": 8,
+		"CHAR_MAX": 127,
+		"CHAR_MIN": -128,
+		"CHILD_MAX": 3900,
+		"CLK_TCK": 100,
+		"INT_MAX": 2147483647,
+		"INT_MIN": -2147483648,
+		"IOV_MAX": 1024,
+		"LOGNAME_MAX": 256,
+		"LONG_BIT": 64,
+		"MB_LEN_MAX": 16,
+		"NGROUPS_MAX": 65536,
+		"NL_ARGMAX": 4096,
+		"NL_LANGMAX": 2048,
+		"NL_MSGMAX": 2147483647,
+		"NL_NMAX": 2147483647,
+		"NL_SETMAX": 2147483647,
+		"NL_TEXTMAX": 2147483647,
+		"NSS_BUFLEN_GROUP": 1024,
+		"NSS_BUFLEN_PASSWD": 1024,
+		"NZERO": 20,
+		"OPEN_MAX": 1024,
+		"PAGESIZE": 4096,
+		"PAGE_SIZE": 4096,
+		"PASS_MAX": 8192,
+		"PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+		"PTHREAD_KEYS_MAX": 1024,
+		"PTHREAD_STACK_MIN": 16384,
+		"PTHREAD_THREADS_MAX": null,
+		"SCHAR_MAX": 127,
+		"SCHAR_MIN": -128,
+		"SHRT_MAX": 32767,
+		"SHRT_MIN": -32768,
+		"SSIZE_MAX": 32767,
+		"TTY_NAME_MAX": 32,
+		"TZNAME_MAX": 6,
+		"UCHAR_MAX": 255,
+		"UINT_MAX": 4294967295,
+		"UIO_MAXIOV": 1024,
+		"ULONG_MAX": 18446744073709552000,
+		"USHRT_MAX": 65535,
+		"WORD_BIT": 32,
+		"_AVPHYS_PAGES": 78135,
+		"_NPROCESSORS_CONF": 1,
+		"_NPROCESSORS_ONLN": 1,
+		"_PHYS_PAGES": 253609,
+		"_POSIX_ARG_MAX": 2097152,
+		"_POSIX_ASYNCHRONOUS_IO": 200809,
+		"_POSIX_CHILD_MAX": 3900,
+		"_POSIX_FSYNC": 200809,
+		"_POSIX_JOB_CONTROL": 1,
+		"_POSIX_MAPPED_FILES": 200809,
+		"_POSIX_MEMLOCK": 200809,
+		"_POSIX_MEMLOCK_RANGE": 200809,
+		"_POSIX_MEMORY_PROTECTION": 200809,
+		"_POSIX_MESSAGE_PASSING": 200809,
+		"_POSIX_NGROUPS_MAX": 65536,
+		"_POSIX_OPEN_MAX": 1024,
+		"_POSIX_PII": null,
+		"_POSIX_PII_INTERNET": null,
+		"_POSIX_PII_INTERNET_DGRAM": null,
+		"_POSIX_PII_INTERNET_STREAM": null,
+		"_POSIX_PII_OSI": null,
+		"_POSIX_PII_OSI_CLTS": null,
+		"_POSIX_PII_OSI_COTS": null,
+		"_POSIX_PII_OSI_M": null,
+		"_POSIX_PII_SOCKET": null,
+		"_POSIX_PII_XTI": null,
+		"_POSIX_POLL": null,
+		"_POSIX_PRIORITIZED_IO": 200809,
+		"_POSIX_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_REALTIME_SIGNALS": 200809,
+		"_POSIX_SAVED_IDS": 1,
+		"_POSIX_SELECT": null,
+		"_POSIX_SEMAPHORES": 200809,
+		"_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+		"_POSIX_SSIZE_MAX": 32767,
+		"_POSIX_STREAM_MAX": 16,
+		"_POSIX_SYNCHRONIZED_IO": 200809,
+		"_POSIX_THREADS": 200809,
+		"_POSIX_THREAD_ATTR_STACKADDR": 200809,
+		"_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+		"_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+		"_POSIX_THREAD_PRIO_INHERIT": 200809,
+		"_POSIX_THREAD_PRIO_PROTECT": 200809,
+		"_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+		"_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+		"_POSIX_THREAD_PROCESS_SHARED": 200809,
+		"_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+		"_POSIX_TIMERS": 200809,
+		"TIMER_MAX": null,
+		"_POSIX_TZNAME_MAX": 6,
+		"_POSIX_VERSION": 200809,
+		"_T_IOV_MAX": null,
+		"_XOPEN_CRYPT": 1,
+		"_XOPEN_ENH_I18N": 1,
+		"_XOPEN_LEGACY": 1,
+		"_XOPEN_REALTIME": 1,
+		"_XOPEN_REALTIME_THREADS": 1,
+		"_XOPEN_SHM": 1,
+		"_XOPEN_UNIX": 1,
+		"_XOPEN_VERSION": 700,
+		"_XOPEN_XCU_VERSION": 4,
+		"_XOPEN_XPG2": 1,
+		"_XOPEN_XPG3": 1,
+		"_XOPEN_XPG4": 1,
+		"BC_BASE_MAX": 99,
+		"BC_DIM_MAX": 2048,
+		"BC_SCALE_MAX": 99,
+		"BC_STRING_MAX": 1000,
+		"CHARCLASS_NAME_MAX": 2048,
+		"COLL_WEIGHTS_MAX": 255,
+		"EQUIV_CLASS_MAX": null,
+		"EXPR_NEST_MAX": 32,
+		"LINE_MAX": 2048,
+		"POSIX2_BC_BASE_MAX": 99,
+		"POSIX2_BC_DIM_MAX": 2048,
+		"POSIX2_BC_SCALE_MAX": 99,
+		"POSIX2_BC_STRING_MAX": 1000,
+		"POSIX2_CHAR_TERM": 200809,
+		"POSIX2_COLL_WEIGHTS_MAX": 255,
+		"POSIX2_C_BIND": 200809,
+		"POSIX2_C_DEV": 200809,
+		"POSIX2_C_VERSION": 200809,
+		"POSIX2_EXPR_NEST_MAX": 32,
+		"POSIX2_FORT_DEV": null,
+		"POSIX2_FORT_RUN": null,
+		"_POSIX2_LINE_MAX": 2048,
+		"POSIX2_LINE_MAX": 2048,
+		"POSIX2_LOCALEDEF": 200809,
+		"POSIX2_RE_DUP_MAX": 32767,
+		"POSIX2_SW_DEV": 200809,
+		"POSIX2_UPE": null,
+		"POSIX2_VERSION": 200809,
+		"RE_DUP_MAX": 32767,
+		"PATH": "/bin:/usr/bin",
+		"CS_PATH": "/bin:/usr/bin",
+		"LFS_CFLAGS": null,
+		"LFS_LDFLAGS": null,
+		"LFS_LIBS": null,
+		"LFS_LINTFLAGS": null,
+		"LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+		"LFS64_LDFLAGS": null,
+		"LFS64_LIBS": null,
+		"LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+		"_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+		"_XBS5_ILP32_OFF32": null,
+		"XBS5_ILP32_OFF32_CFLAGS": null,
+		"XBS5_ILP32_OFF32_LDFLAGS": null,
+		"XBS5_ILP32_OFF32_LIBS": null,
+		"XBS5_ILP32_OFF32_LINTFLAGS": null,
+		"_XBS5_ILP32_OFFBIG": null,
+		"XBS5_ILP32_OFFBIG_CFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LDFLAGS": null,
+		"XBS5_ILP32_OFFBIG_LIBS": null,
+		"XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+		"_XBS5_LP64_OFF64": 1,
+		"XBS5_LP64_OFF64_CFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LDFLAGS": "-m64",
+		"XBS5_LP64_OFF64_LIBS": null,
+		"XBS5_LP64_OFF64_LINTFLAGS": null,
+		"_XBS5_LPBIG_OFFBIG": null,
+		"XBS5_LPBIG_OFFBIG_CFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+		"XBS5_LPBIG_OFFBIG_LIBS": null,
+		"XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_ILP32_OFF32": null,
+		"POSIX_V6_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFF32_LIBS": null,
+		"POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+		"_POSIX_V6_ILP32_OFFBIG": null,
+		"POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V6_LP64_OFF64": 1,
+		"POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V6_LP64_OFF64_LIBS": null,
+		"POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V6_LPBIG_OFFBIG": null,
+		"POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_ILP32_OFF32": null,
+		"POSIX_V7_ILP32_OFF32_CFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFF32_LIBS": null,
+		"POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+		"_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+		"_POSIX_V7_ILP32_OFFBIG": null,
+		"POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_ILP32_OFFBIG_LIBS": null,
+		"POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+		"_POSIX_V7_LP64_OFF64": 1,
+		"POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+		"POSIX_V7_LP64_OFF64_LIBS": null,
+		"POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+		"_POSIX_V7_LPBIG_OFFBIG": null,
+		"POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+		"POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+		"_POSIX_ADVISORY_INFO": 200809,
+		"_POSIX_BARRIERS": 200809,
+		"_POSIX_BASE": null,
+		"_POSIX_C_LANG_SUPPORT": null,
+		"_POSIX_C_LANG_SUPPORT_R": null,
+		"_POSIX_CLOCK_SELECTION": 200809,
+		"_POSIX_CPUTIME": 200809,
+		"_POSIX_THREAD_CPUTIME": 200809,
+		"_POSIX_DEVICE_SPECIFIC": null,
+		"_POSIX_DEVICE_SPECIFIC_R": null,
+		"_POSIX_FD_MGMT": null,
+		"_POSIX_FIFO": null,
+		"_POSIX_PIPE": null,
+		"_POSIX_FILE_ATTRIBUTES": null,
+		"_POSIX_FILE_LOCKING": null,
+		"_POSIX_FILE_SYSTEM": null,
+		"_POSIX_MONOTONIC_CLOCK": 200809,
+		"_POSIX_MULTI_PROCESS": null,
+		"_POSIX_SINGLE_PROCESS": null,
+		"_POSIX_NETWORKING": null,
+		"_POSIX_READER_WRITER_LOCKS": 200809,
+		"_POSIX_SPIN_LOCKS": 200809,
+		"_POSIX_REGEXP": 1,
+		"_REGEX_VERSION": null,
+		"_POSIX_SHELL": 1,
+		"_POSIX_SIGNALS": null,
+		"_POSIX_SPAWN": 200809,
+		"_POSIX_SPORADIC_SERVER": null,
+		"_POSIX_THREAD_SPORADIC_SERVER": null,
+		"_POSIX_SYSTEM_DATABASE": null,
+		"_POSIX_SYSTEM_DATABASE_R": null,
+		"_POSIX_TIMEOUTS": 200809,
+		"_POSIX_TYPED_MEMORY_OBJECTS": null,
+		"_POSIX_USER_GROUPS": null,
+		"_POSIX_USER_GROUPS_R": null,
+		"POSIX2_PBS": null,
+		"POSIX2_PBS_ACCOUNTING": null,
+		"POSIX2_PBS_LOCATE": null,
+		"POSIX2_PBS_TRACK": null,
+		"POSIX2_PBS_MESSAGE": null,
+		"SYMLOOP_MAX": null,
+		"STREAM_MAX": 16,
+		"AIO_LISTIO_MAX": null,
+		"AIO_MAX": null,
+		"AIO_PRIO_DELTA_MAX": 20,
+		"DELAYTIMER_MAX": 2147483647,
+		"HOST_NAME_MAX": 64,
+		"LOGIN_NAME_MAX": 256,
+		"MQ_OPEN_MAX": null,
+		"MQ_PRIO_MAX": 32768,
+		"_POSIX_DEVICE_IO": null,
+		"_POSIX_TRACE": null,
+		"_POSIX_TRACE_EVENT_FILTER": null,
+		"_POSIX_TRACE_INHERIT": null,
+		"_POSIX_TRACE_LOG": null,
+		"RTSIG_MAX": 32,
+		"SEM_NSEMS_MAX": null,
+		"SEM_VALUE_MAX": 2147483647,
+		"SIGQUEUE_MAX": 3900,
+		"FILESIZEBITS": 64,
+		"POSIX_ALLOC_SIZE_MIN": 4096,
+		"POSIX_REC_INCR_XFER_SIZE": null,
+		"POSIX_REC_MAX_XFER_SIZE": null,
+		"POSIX_REC_MIN_XFER_SIZE": 4096,
+		"POSIX_REC_XFER_ALIGN": 4096,
+		"SYMLINK_MAX": null,
+		"GNU_LIBC_VERSION": "glibc 2.23",
+		"GNU_LIBPTHREAD_VERSION": "NPTL 2.23",
+		"POSIX2_SYMLINKS": 1,
+		"LEVEL1_ICACHE_SIZE": 32768,
+		"LEVEL1_ICACHE_ASSOC": 8,
+		"LEVEL1_ICACHE_LINESIZE": 64,
+		"LEVEL1_DCACHE_SIZE": 32768,
+		"LEVEL1_DCACHE_ASSOC": 8,
+		"LEVEL1_DCACHE_LINESIZE": 64,
+		"LEVEL2_CACHE_SIZE": 262144,
+		"LEVEL2_CACHE_ASSOC": 8,
+		"LEVEL2_CACHE_LINESIZE": 64,
+		"LEVEL3_CACHE_SIZE": 31457280,
+		"LEVEL3_CACHE_ASSOC": 20,
+		"LEVEL3_CACHE_LINESIZE": 64,
+		"LEVEL4_CACHE_SIZE": 0,
+		"LEVEL4_CACHE_ASSOC": 0,
+		"LEVEL4_CACHE_LINESIZE": 0,
+		"IPV6": 200809,
+		"RAW_SOCKETS": 200809,
+		"_POSIX_IPV6": 200809,
+		"_POSIX_RAW_SOCKETS": 200809
+	},
+	"time": {
+		"timezone": "UTC"
+	},
+	"uptime": "14 seconds",
+	"uptime_seconds": 14,
+	"virtualization": {
+		"systems": {
+			"docker": "host",
+			"xen": "guest"
+		},
+		"system": "xen",
+		"role": "guest"
+	}
+}

--- a/scans/ubuntu-ec2-train.json
+++ b/scans/ubuntu-ec2-train.json
@@ -178,9 +178,13 @@
 		}
 	},
 	"chef_packages": {
+		"chef": {
+			"version": "14.11.21",
+			"chefroot": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.11.21/lib"
+		},
 		"ohai": {
-			"version": "15.0.30",
-			"ohai_root": "/Users/franklinwebber/src/ohai/lib/ohai"
+			"version": "14.8.10",
+			"ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.5.0/gems/ohai-14.8.10/lib"
 		}
 	},
 	"cloud": {
@@ -223,16 +227,16 @@
 				"eth0": {
 					"tx": {
 						"queuelen": "1000",
-						"bytes": "134131",
-						"packets": "1036",
+						"bytes": "5319652",
+						"packets": "33323",
 						"errors": "0",
 						"drop": "0",
 						"carrier": "0",
 						"collisions": "0"
 					},
 					"rx": {
-						"bytes": "569521",
-						"packets": "1115",
+						"bytes": "34029399",
+						"packets": "38452",
 						"errors": "0",
 						"drop": "0",
 						"overrun": "0"
@@ -325,7 +329,6 @@
 	"dmi": {
 		"dmidecode_version": "3.0"
 	},
-	"docker": {},
 	"domain": null,
 	"ec2": {
 		"ami_id": "ami-0565af6e282977273",
@@ -383,464 +386,464 @@
 		"passwd": {
 			"root": {
 				"dir": "/root",
-				"gid": "0",
-				"uid": "0",
+				"gid": 0,
+				"uid": 0,
 				"shell": "/bin/bash",
 				"gecos": "root"
 			},
 			"daemon": {
 				"dir": "/usr/sbin",
-				"gid": "1",
-				"uid": "1",
+				"gid": 1,
+				"uid": 1,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "daemon"
 			},
 			"bin": {
 				"dir": "/bin",
-				"gid": "2",
-				"uid": "2",
+				"gid": 2,
+				"uid": 2,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "bin"
 			},
 			"sys": {
 				"dir": "/dev",
-				"gid": "3",
-				"uid": "3",
+				"gid": 3,
+				"uid": 3,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "sys"
 			},
 			"sync": {
 				"dir": "/bin",
-				"gid": "65534",
-				"uid": "4",
+				"gid": 65534,
+				"uid": 4,
 				"shell": "/bin/sync",
 				"gecos": "sync"
 			},
 			"games": {
 				"dir": "/usr/games",
-				"gid": "60",
-				"uid": "5",
+				"gid": 60,
+				"uid": 5,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "games"
 			},
 			"man": {
 				"dir": "/var/cache/man",
-				"gid": "12",
-				"uid": "6",
+				"gid": 12,
+				"uid": 6,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "man"
 			},
 			"lp": {
 				"dir": "/var/spool/lpd",
-				"gid": "7",
-				"uid": "7",
+				"gid": 7,
+				"uid": 7,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "lp"
 			},
 			"mail": {
 				"dir": "/var/mail",
-				"gid": "8",
-				"uid": "8",
+				"gid": 8,
+				"uid": 8,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "mail"
 			},
 			"news": {
 				"dir": "/var/spool/news",
-				"gid": "9",
-				"uid": "9",
+				"gid": 9,
+				"uid": 9,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "news"
 			},
 			"uucp": {
 				"dir": "/var/spool/uucp",
-				"gid": "10",
-				"uid": "10",
+				"gid": 10,
+				"uid": 10,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "uucp"
 			},
 			"proxy": {
 				"dir": "/bin",
-				"gid": "13",
-				"uid": "13",
+				"gid": 13,
+				"uid": 13,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "proxy"
 			},
 			"www-data": {
 				"dir": "/var/www",
-				"gid": "33",
-				"uid": "33",
+				"gid": 33,
+				"uid": 33,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "www-data"
 			},
 			"backup": {
 				"dir": "/var/backups",
-				"gid": "34",
-				"uid": "34",
+				"gid": 34,
+				"uid": 34,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "backup"
 			},
 			"list": {
 				"dir": "/var/list",
-				"gid": "38",
-				"uid": "38",
+				"gid": 38,
+				"uid": 38,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "Mailing List Manager"
 			},
 			"irc": {
 				"dir": "/var/run/ircd",
-				"gid": "39",
-				"uid": "39",
+				"gid": 39,
+				"uid": 39,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "ircd"
 			},
 			"gnats": {
 				"dir": "/var/lib/gnats",
-				"gid": "41",
-				"uid": "41",
+				"gid": 41,
+				"uid": 41,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "Gnats Bug-Reporting System (admin)"
 			},
 			"nobody": {
 				"dir": "/nonexistent",
-				"gid": "65534",
-				"uid": "65534",
+				"gid": 65534,
+				"uid": 65534,
 				"shell": "/usr/sbin/nologin",
 				"gecos": "nobody"
 			},
 			"systemd-timesync": {
 				"dir": "/run/systemd",
-				"gid": "102",
-				"uid": "100",
+				"gid": 102,
+				"uid": 100,
 				"shell": "/bin/false",
 				"gecos": "systemd Time Synchronization,,,"
 			},
 			"systemd-network": {
 				"dir": "/run/systemd/netif",
-				"gid": "103",
-				"uid": "101",
+				"gid": 103,
+				"uid": 101,
 				"shell": "/bin/false",
 				"gecos": "systemd Network Management,,,"
 			},
 			"systemd-resolve": {
 				"dir": "/run/systemd/resolve",
-				"gid": "104",
-				"uid": "102",
+				"gid": 104,
+				"uid": 102,
 				"shell": "/bin/false",
 				"gecos": "systemd Resolver,,,"
 			},
 			"systemd-bus-proxy": {
 				"dir": "/run/systemd",
-				"gid": "105",
-				"uid": "103",
+				"gid": 105,
+				"uid": 103,
 				"shell": "/bin/false",
 				"gecos": "systemd Bus Proxy,,,"
 			},
 			"syslog": {
 				"dir": "/home/syslog",
-				"gid": "108",
-				"uid": "104",
+				"gid": 108,
+				"uid": 104,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"_apt": {
 				"dir": "/nonexistent",
-				"gid": "65534",
-				"uid": "105",
+				"gid": 65534,
+				"uid": 105,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"lxd": {
 				"dir": "/var/lib/lxd/",
-				"gid": "65534",
-				"uid": "106",
+				"gid": 65534,
+				"uid": 106,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"messagebus": {
 				"dir": "/var/run/dbus",
-				"gid": "111",
-				"uid": "107",
+				"gid": 111,
+				"uid": 107,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"uuidd": {
 				"dir": "/run/uuidd",
-				"gid": "112",
-				"uid": "108",
+				"gid": 112,
+				"uid": 108,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"dnsmasq": {
 				"dir": "/var/lib/misc",
-				"gid": "65534",
-				"uid": "109",
+				"gid": 65534,
+				"uid": 109,
 				"shell": "/bin/false",
 				"gecos": "dnsmasq,,,"
 			},
 			"sshd": {
 				"dir": "/var/run/sshd",
-				"gid": "65534",
-				"uid": "110",
+				"gid": 65534,
+				"uid": 110,
 				"shell": "/usr/sbin/nologin",
 				"gecos": ""
 			},
 			"pollinate": {
 				"dir": "/var/cache/pollinate",
-				"gid": "1",
-				"uid": "111",
+				"gid": 1,
+				"uid": 111,
 				"shell": "/bin/false",
 				"gecos": ""
 			},
 			"ubuntu": {
 				"dir": "/home/ubuntu",
-				"gid": "1000",
-				"uid": "1000",
+				"gid": 1000,
+				"uid": 1000,
 				"shell": "/bin/bash",
 				"gecos": "Ubuntu"
 			}
 		},
 		"group": {
 			"root": {
-				"gid": "0",
+				"gid": 0,
 				"members": []
 			},
 			"daemon": {
-				"gid": "1",
+				"gid": 1,
 				"members": []
 			},
 			"bin": {
-				"gid": "2",
+				"gid": 2,
 				"members": []
 			},
 			"sys": {
-				"gid": "3",
+				"gid": 3,
 				"members": []
 			},
 			"adm": {
-				"gid": "4",
+				"gid": 4,
 				"members": [
 					"syslog",
 					"ubuntu"
 				]
 			},
 			"tty": {
-				"gid": "5",
+				"gid": 5,
 				"members": []
 			},
 			"disk": {
-				"gid": "6",
+				"gid": 6,
 				"members": []
 			},
 			"lp": {
-				"gid": "7",
+				"gid": 7,
 				"members": []
 			},
 			"mail": {
-				"gid": "8",
+				"gid": 8,
 				"members": []
 			},
 			"news": {
-				"gid": "9",
+				"gid": 9,
 				"members": []
 			},
 			"uucp": {
-				"gid": "10",
+				"gid": 10,
 				"members": []
 			},
 			"man": {
-				"gid": "12",
+				"gid": 12,
 				"members": []
 			},
 			"proxy": {
-				"gid": "13",
+				"gid": 13,
 				"members": []
 			},
 			"kmem": {
-				"gid": "15",
+				"gid": 15,
 				"members": []
 			},
 			"dialout": {
-				"gid": "20",
+				"gid": 20,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"fax": {
-				"gid": "21",
+				"gid": 21,
 				"members": []
 			},
 			"voice": {
-				"gid": "22",
+				"gid": 22,
 				"members": []
 			},
 			"cdrom": {
-				"gid": "24",
+				"gid": 24,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"floppy": {
-				"gid": "25",
+				"gid": 25,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"tape": {
-				"gid": "26",
+				"gid": 26,
 				"members": []
 			},
 			"sudo": {
-				"gid": "27",
+				"gid": 27,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"audio": {
-				"gid": "29",
+				"gid": 29,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"dip": {
-				"gid": "30",
+				"gid": 30,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"www-data": {
-				"gid": "33",
+				"gid": 33,
 				"members": []
 			},
 			"backup": {
-				"gid": "34",
+				"gid": 34,
 				"members": []
 			},
 			"operator": {
-				"gid": "37",
+				"gid": 37,
 				"members": []
 			},
 			"list": {
-				"gid": "38",
+				"gid": 38,
 				"members": []
 			},
 			"irc": {
-				"gid": "39",
+				"gid": 39,
 				"members": []
 			},
 			"src": {
-				"gid": "40",
+				"gid": 40,
 				"members": []
 			},
 			"gnats": {
-				"gid": "41",
+				"gid": 41,
 				"members": []
 			},
 			"shadow": {
-				"gid": "42",
+				"gid": 42,
 				"members": []
 			},
 			"utmp": {
-				"gid": "43",
+				"gid": 43,
 				"members": []
 			},
 			"video": {
-				"gid": "44",
+				"gid": 44,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"sasl": {
-				"gid": "45",
+				"gid": 45,
 				"members": []
 			},
 			"plugdev": {
-				"gid": "46",
+				"gid": 46,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"staff": {
-				"gid": "50",
+				"gid": 50,
 				"members": []
 			},
 			"games": {
-				"gid": "60",
+				"gid": 60,
 				"members": []
 			},
 			"users": {
-				"gid": "100",
+				"gid": 100,
 				"members": []
 			},
 			"nogroup": {
-				"gid": "65534",
+				"gid": 65534,
 				"members": []
 			},
 			"systemd-journal": {
-				"gid": "101",
+				"gid": 101,
 				"members": []
 			},
 			"systemd-timesync": {
-				"gid": "102",
+				"gid": 102,
 				"members": []
 			},
 			"systemd-network": {
-				"gid": "103",
+				"gid": 103,
 				"members": []
 			},
 			"systemd-resolve": {
-				"gid": "104",
+				"gid": 104,
 				"members": []
 			},
 			"systemd-bus-proxy": {
-				"gid": "105",
+				"gid": 105,
 				"members": []
 			},
 			"input": {
-				"gid": "106",
+				"gid": 106,
 				"members": []
 			},
 			"crontab": {
-				"gid": "107",
+				"gid": 107,
 				"members": []
 			},
 			"syslog": {
-				"gid": "108",
+				"gid": 108,
 				"members": []
 			},
 			"netdev": {
-				"gid": "109",
+				"gid": 109,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"lxd": {
-				"gid": "110",
+				"gid": 110,
 				"members": [
 					"ubuntu"
 				]
 			},
 			"messagebus": {
-				"gid": "111",
+				"gid": 111,
 				"members": []
 			},
 			"uuidd": {
-				"gid": "112",
+				"gid": 112,
 				"members": []
 			},
 			"ssh": {
-				"gid": "113",
+				"gid": 113,
 				"members": []
 			},
 			"mlocate": {
-				"gid": "114",
+				"gid": 114,
 				"members": []
 			},
 			"admin": {
-				"gid": "115",
+				"gid": 115,
 				"members": []
 			},
 			"ubuntu": {
-				"gid": "1000",
+				"gid": 1000,
 				"members": []
 			}
 		}
@@ -899,12 +902,12 @@
 			},
 			"/dev/xvda1": {
 				"kb_size": "8065444",
-				"kb_used": "1154124",
-				"kb_available": "6894936",
+				"kb_used": "1153112",
+				"kb_available": "6895948",
 				"percent_used": "15%",
 				"total_inodes": "1024000",
-				"inodes_used": "73359",
-				"inodes_available": "950641",
+				"inodes_used": "73246",
+				"inodes_available": "950754",
 				"inodes_percent_used": "8%",
 				"fs_type": "ext4",
 				"mount_options": [
@@ -1182,12 +1185,12 @@
 			},
 			"/": {
 				"kb_size": "8065444",
-				"kb_used": "1154124",
-				"kb_available": "6894936",
+				"kb_used": "1153112",
+				"kb_available": "6895948",
 				"percent_used": "15%",
 				"total_inodes": "1024000",
-				"inodes_used": "73359",
-				"inodes_available": "950641",
+				"inodes_used": "73246",
+				"inodes_available": "950754",
 				"inodes_percent_used": "8%",
 				"fs_type": "ext4",
 				"mount_options": [
@@ -1671,13 +1674,13 @@
 			"/dev/xvda1,/": {
 				"device": "/dev/xvda1",
 				"kb_size": "8065444",
-				"kb_used": "1154124",
-				"kb_available": "6894936",
+				"kb_used": "1153112",
+				"kb_available": "6895948",
 				"percent_used": "15%",
 				"mount": "/",
 				"total_inodes": "1024000",
-				"inodes_used": "73359",
-				"inodes_available": "950641",
+				"inodes_used": "73246",
+				"inodes_available": "950754",
 				"inodes_percent_used": "8%",
 				"fs_type": "ext4",
 				"mount_options": [
@@ -2113,8 +2116,8 @@
 		"kernel": "Linux 4.4.0-1075-aws",
 		"architecture": "x86-64"
 	},
-	"idletime": "01 seconds",
-	"idletime_seconds": 1,
+	"idletime": "39 minutes 13 seconds",
+	"idletime_seconds": 2353,
 	"init_package": "systemd",
 	"ip6address": "fe80::8a3:feff:fe6c:de9e",
 	"ipaddress": "172.30.0.152",
@@ -2328,24 +2331,24 @@
 			"2M": "1011712kB"
 		},
 		"total": "1014436kB",
-		"free": "524844kB",
-		"available": "794232kB",
-		"buffers": "29108kB",
-		"cached": "364244kB",
-		"active": "152992kB",
-		"inactive": "271828kB",
-		"dirty": "16504kB",
+		"free": "314124kB",
+		"available": "773692kB",
+		"buffers": "43732kB",
+		"cached": "522688kB",
+		"active": "195040kB",
+		"inactive": "404788kB",
+		"dirty": "12kB",
 		"writeback": "0kB",
-		"anon_pages": "35084kB",
-		"mapped": "46236kB",
-		"slab": "38364kB",
-		"slab_reclaimable": "18988kB",
-		"slab_unreclaim": "19376kB",
-		"page_tables": "2952kB",
+		"anon_pages": "37056kB",
+		"mapped": "46904kB",
+		"slab": "74160kB",
+		"slab_reclaimable": "53272kB",
+		"slab_unreclaim": "20888kB",
+		"page_tables": "3008kB",
 		"nfs_unstable": "0kB",
 		"bounce": "0kB",
 		"commit_limit": "507216kB",
-		"committed_as": "283084kB",
+		"committed_as": "299448kB",
 		"vmalloc_total": "34359738367kB",
 		"vmalloc_used": "0kB",
 		"vmalloc_chunk": "0kB",
@@ -2437,7 +2440,7 @@
 		"default_interface": "eth0",
 		"default_gateway": "172.30.0.1"
 	},
-	"ohai_time": 1554351530.9332821,
+	"ohai_time": 1554353924.525873,
 	"os": "linux",
 	"os_version": "4.4.0-1075-aws",
 	"packages": {
@@ -4331,7 +4334,7 @@
 		"ULONG_MAX": 18446744073709552000,
 		"USHRT_MAX": 65535,
 		"WORD_BIT": 32,
-		"_AVPHYS_PAGES": 78135,
+		"_AVPHYS_PAGES": 78483,
 		"_NPROCESSORS_CONF": 1,
 		"_NPROCESSORS_ONLN": 1,
 		"_PHYS_PAGES": 253609,
@@ -4592,11 +4595,10 @@
 	"time": {
 		"timezone": "UTC"
 	},
-	"uptime": "14 seconds",
-	"uptime_seconds": 14,
+	"uptime": "39 minutes 53 seconds",
+	"uptime_seconds": 2393,
 	"virtualization": {
 		"systems": {
-			"docker": "host",
 			"xen": "guest"
 		},
 		"system": "xen",


### PR DESCRIPTION
## Ubuntu - Running in AWS

Running the command

```bash
$ bin/ohai --target ssh://ubuntu@IPADDRESS -i ~/.ssh/ohai.pem
```

### Plugins

Need to fix the following plugin discrepancies in the output:

- [x] `block_device/xvda` present in train scan only - I assume that local ohai is out-of-date
- [x] `chef_packages/ohai` reports local ohai
- [x] `etc/passwd/USERS` the `gid` and `uid` are currently strings instead of numbers
- [x] `memory/directmap` present in train scan only - I assume that local ohai is out-of-date
- [x] `memory/free` reports lower in local scan - I assume that this because we're not loading Ruby and Ohai.
- [x] `virtualization/systems/docker` is present in train scan and set to `host`. Absent in local
- [x] `systemd_paths` are missing in train scan
- [x] `chef_packages/chef` is present in train scan. I thin the implementation works better
### Performance

*Running Locally* with Ohai 14.8.10
```
TBD
```
*Running remotely* with this Ohai (2 minutes)
```
TBD
```